### PR TITLE
Add a googletest harness for CovidSim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ build_*/
 *.vcxproj.user
 tests/us-output/
 tests/regressiontest_UK_100th/
+
+testCovidSimBuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,19 @@ dist: bionic
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - cmake
       - cmake-data
       - build-essential
+      - g++-9
 
 branches:
   only:
     - master
 
 script: 
-  - ./cleanBuildTests.sh
+  - CXX=g++-9 ./cleanBuildTests.sh
   - cd tests
   - ./regressiontest_UK_100th.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+
+dist: bionic
+
+addons:
+  apt:
+    packages:
+      - cmake
+      - cmake-data
+      - build-essential
+
+branches:
+  only:
+    - master
+
+script: 
+  - ./cleanBuildTests.sh
+  - cd tests
+  - ./regressiontest_UK_100th.py

--- a/cleanBuildTests.sh
+++ b/cleanBuildTests.sh
@@ -47,7 +47,7 @@ function DoTests {
 
     cmake -DCMAKE_MODULE_PATH:PATH=$MODULE_PATH -DCMAKE_PREFIX_PATH:PATH=$PREFIX_PATH -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PATH $srcDirRelToTestDir/tests || exit 1
     make -j 3 || exit 1
-    make test
+    make test || exit 1
 }
 
 if [[ "$1" == "-deepClean" ]]; then

--- a/cleanBuildTests.sh
+++ b/cleanBuildTests.sh
@@ -2,13 +2,63 @@
 
 testDir=testCovidSimBuild
 srcDirRelToTestDir=../src
+depsDir="deps"
+installDir="$depsDir/install"
 
-rm -rf $testDir
-mkdir $testDir
+function InstallGTest {
+    installTarget=$1
 
-pushd $testDir
-cmake $srcDirRelToTestDir/tests || exit 1
-make -j 3 || exit 1
-make test
+    if [[ -e googletest ]]; then
+        pushd googletest
+            git pull || exit 1
+        popd
+    else
+        git clone https://github.com/google/googletest.git || exit 1
+    fi
+    mkdir -p googletest/build || exit 1
+    pushd googletest/build || exit 1
+        cmake -DCMAKE_BUILD_TYPE=Release "-DCMAKE_INSTALL_PREFIX:PATH=$installTarget" .. || exit 1
+        make -j 3 || exit 1
+        make install || exit 1
+    popd || exit 1
+
+}
+
+function InstallDeps {
+    mkdir -p $depsDir
+    mkdir -p $installDir
+
+    pushd $installDir || exit 1
+        fullInstallDir=$PWD
+    popd || exit 1
+
+    pushd $depsDir || exit 1
+        InstallGTest $fullInstallDir
+    popd || exit 1
+}
+
+function DoTests {
+    pushd $installDir || exit 1
+        fullInstallDir=$PWD
+    popd || exit 1
+    MODULE_PATH="$fullInstallDir/lib/cmake"
+    PREFIX_PATH="$fullInstallDir/lib/cmake"
+    INSTALL_PATH="$fullInstallDir"
+
+    cmake -DCMAKE_MODULE_PATH:PATH=$MODULE_PATH -DCMAKE_PREFIX_PATH:PATH=$PREFIX_PATH -DCMAKE_INSTALL_PREFIX:PATH=$INSTALL_PATH $srcDirRelToTestDir/tests || exit 1
+    make -j 3 || exit 1
+    make test
+}
+
+if [[ "$1" == "-deepClean" ]]; then
+    rm -rf $testDir
+fi
+
+mkdir -p $testDir
+pushd $testDir || exit 1
+    InstallDeps
+    DoTests
+popd || exit 1
+
 
 

--- a/cleanBuildTests.sh
+++ b/cleanBuildTests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+testDir=testCovidSimBuild
+srcDirRelToTestDir=../src
+
+rm -rf $testDir
+mkdir $testDir
+
+pushd $testDir
+cmake $srcDirRelToTestDir/tests || exit 1
+make -j 3 || exit 1
+make test
+
+

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,3 +1,6 @@
 CovidSim
 CMakeSettings.json
 *.o
+
+.idea
+cmake-build-*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,8 @@ endif()
 set(CMAKE_CXX_STANDARD 11)
 
 # CovidSim target
-add_executable(CovidSim CovidSim.cpp CovidSim.h binio.cpp binio.h Rand.cpp Rand.h Constants.h Country.h MachineDefines.h Error.cpp Error.h Dist.cpp Dist.h Kernels.cpp Kernels.h Bitmap.cpp Bitmap.h Model.h Param.h SetupModel.cpp SetupModel.h SharedFuncs.h ModelMacros.h InfStat.h CalcInfSusc.cpp CalcInfSusc.h Sweep.cpp Sweep.h Update.cpp Update.h)
+add_executable(CovidSim CovidSim.cpp CovidSim.h binio.cpp binio.h Rand.cpp Rand.h Constants.h Country.h MachineDefines.h Error.cpp Error.h Dist.cpp Dist.h Kernels.cpp Kernels.h Bitmap.cpp Bitmap.h Model.h Param.h SetupModel.cpp SetupModel.h SharedFuncs.h ModelMacros.h InfStat.h CalcInfSusc.cpp CalcInfSusc.h Sweep.cpp Sweep.h Update.cpp Update.h
+ main.cpp)
 target_include_directories(CovidSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 if(USE_OPENMP)
   target_link_libraries(CovidSim PUBLIC OpenMP::OpenMP_CXX)

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -113,9 +113,9 @@ int PlaceDistDistrib[NUM_PLACE_TYPES][MAX_DIST], PlaceSizeDistrib[NUM_PLACE_TYPE
 void
 ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
-                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i, int GotP,
+                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i,
                  int GotO, int &GotPP, int &GotAP, int &GotScF, int &Perr) {
-    int GotL = 0, GotS = 0;
+    int GotL = 0, GotS = 0, GotP = 0;
     if (argc < 7) Perr = 1;
     else
     {
@@ -274,10 +274,10 @@ ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile
 int _main(int argc, const char* argv[])
 {
 	char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
-	int i, GotP, GotPP, GotO, GotAP, GotScF, Perr, cl;
+	int i, GotPP, GotO, GotAP, GotScF, Perr, cl;
 
 	///// Flags to ensure various parameters have been read; set to false as default.
-	GotP = GotO = GotAP = GotScF = GotPP = 0;
+	GotO = GotAP = GotScF = GotPP = 0;
 
 	Perr = 0;
 	fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
@@ -287,7 +287,7 @@ int _main(int argc, const char* argv[])
 
     ParseCmdLineArgs(argc, argv, ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile,
                      InterventionFile,
-                     PreParamFile, buf, sep, i, GotP, GotO, GotPP, GotAP, GotScF, Perr);
+                     PreParamFile, buf, sep, i, GotO, GotPP, GotAP, GotScF, Perr);
 
     ///// END Read in command line arguments
 

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -208,7 +208,7 @@ ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile
             else if (argv[i][1] == 'A' && argv[i][2] == 'P' && argv[i][3] == ':')
             {
                 GotAP = 1;
-                sscanf(&argv[i][3], "%s", AirTravelFile);
+                sscanf(&argv[i][4], "%s", AirTravelFile);
             }
             else if (argv[i][1] == 's' && argv[i][2] == ':')
             {

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -114,8 +114,8 @@ void
 ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
                  char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i,
-                 int GotO, int &GotPP, int &GotAP, int &GotScF, int &Perr) {
-    int GotL = 0, GotS = 0, GotP = 0;
+                 int &GotPP, int &GotAP, int &GotScF, int &Perr) {
+    int GotL = 0, GotS = 0, GotO = 0, GotP = 0;
     if (argc < 7) Perr = 1;
     else
     {
@@ -274,10 +274,10 @@ ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile
 int _main(int argc, const char* argv[])
 {
 	char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
-	int i, GotPP, GotO, GotAP, GotScF, Perr, cl;
+	int i, GotPP, GotAP, GotScF, Perr, cl;
 
 	///// Flags to ensure various parameters have been read; set to false as default.
-	GotO = GotAP = GotScF = GotPP = 0;
+	GotAP = GotScF = GotPP = 0;
 
 	Perr = 0;
 	fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
@@ -287,7 +287,7 @@ int _main(int argc, const char* argv[])
 
     ParseCmdLineArgs(argc, argv, ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile,
                      InterventionFile,
-                     PreParamFile, buf, sep, i, GotO, GotPP, GotAP, GotScF, Perr);
+                     PreParamFile, buf, sep, i, GotPP, GotAP, GotScF, Perr);
 
     ///// END Read in command line arguments
 

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -114,7 +114,8 @@ void
 ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
                  char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i, int GotP,
-                 int GotO, int GotL, int GotS, int &GotPP, int &GotAP, int &GotScF, int &Perr) {
+                 int GotO, int &GotPP, int &GotAP, int &GotScF, int &Perr) {
+    int GotL = 0, GotS = 0;
     if (argc < 7) Perr = 1;
     else
     {
@@ -273,10 +274,10 @@ ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile
 int _main(int argc, const char* argv[])
 {
 	char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
-	int i, GotP, GotPP, GotO, GotL, GotS, GotAP, GotScF, Perr, cl;
+	int i, GotP, GotPP, GotO, GotAP, GotScF, Perr, cl;
 
 	///// Flags to ensure various parameters have been read; set to false as default.
-	GotP = GotO = GotL = GotS = GotAP = GotScF = GotPP = 0;
+	GotP = GotO = GotAP = GotScF = GotPP = 0;
 
 	Perr = 0;
 	fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
@@ -286,7 +287,7 @@ int _main(int argc, const char* argv[])
 
     ParseCmdLineArgs(argc, argv, ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile,
                      InterventionFile,
-                     PreParamFile, buf, sep, i, GotP, GotO, GotL, GotS, GotPP, GotAP, GotScF, Perr);
+                     PreParamFile, buf, sep, i, GotP, GotO, GotPP, GotAP, GotScF, Perr);
 
     ///// END Read in command line arguments
 

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -110,7 +110,7 @@ int PlaceDistDistrib[NUM_PLACE_TYPES][MAX_DIST], PlaceSizeDistrib[NUM_PLACE_TYPE
 /* int NumPC,NumPCD; */
 #define MAXINTFILE 10
 
-int main(int argc, char* argv[])
+int _main(int argc, char* argv[])
 {
 	char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
 	int i, GotP, GotPP, GotO, GotL, GotS, GotAP, GotScF, Perr, cl;
@@ -427,6 +427,8 @@ int main(int argc, char* argv[])
 	fprintf(stderr, "Extinction in %i out of %i runs\n", P.NRactE, P.NRactNE + P.NRactE);
 	fprintf(stderr, "Model ran in %lf seconds\n", ((double)(clock() - cl)) / CLOCKS_PER_SEC);
 	fprintf(stderr, "Model finished\n");
+
+	return 0;
 }
 
 

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -273,6 +273,8 @@ ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile
         {
             sprintf(PreParamFile, ".." DIRECTORY_SEPARATOR "Pre_%s", ParamFile);
         }
+
+        sprintf(OutFile, "%s", OutFileBase);
     }
 }
 
@@ -319,7 +321,6 @@ int _main(int argc, const char* argv[])
 
     ///// END Read in command line arguments
 
-	sprintf(OutFile, "%s", OutFileBase);
 
 	fprintf(stderr, "Param=%s\nOut=%s\nDens=%s\n", ParamFile, OutFile, DensityFile);
 	if (Perr) ERR_CRITICAL_FMT("Syntax:\n%s /P:ParamFile /O:OutputFile [/AP:AirTravelFile] [/s:SchoolFile] [/D:DensityFile] [/L:NetworkFileToLoad | /S:NetworkFileToSave] [/R:R0scaling] SetupSeed1 SetupSeed2 RunSeed1 RunSeed2\n", argv[0]);

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -114,8 +114,8 @@ void
 ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
                  char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep,
-                 int &GotPP, int &GotAP, int &GotScF, int &Perr) {
-    int GotL = 0, GotS = 0, GotO = 0, GotP = 0;
+                 int &GotAP, int &GotScF, int &Perr) {
+    int GotL = 0, GotS = 0, GotO = 0, GotP = 0, GotPP = 0;
     if (argc < 7) Perr = 1;
     else
     {
@@ -268,6 +268,11 @@ ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile
             }
         }
         if (((GotS) && (GotL)) || (!GotP) || (!GotO)) Perr = 1;
+
+        if (!GotPP)
+        {
+            sprintf(PreParamFile, ".." DIRECTORY_SEPARATOR "Pre_%s", ParamFile);
+        }
     }
 }
 
@@ -297,10 +302,10 @@ void SetupThreads() {
 int _main(int argc, const char* argv[])
 {
 	char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
-	int i, GotPP, GotAP, GotScF, Perr, cl;
+	int i, GotAP, GotScF, Perr, cl;
 
 	///// Flags to ensure various parameters have been read; set to false as default.
-	GotAP = GotScF = GotPP = 0;
+	GotAP = GotScF = 0;
 
 	Perr = 0;
 	fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
@@ -310,7 +315,7 @@ int _main(int argc, const char* argv[])
 
     ParseCmdLineArgs(argc, argv, ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile,
                      InterventionFile,
-                     PreParamFile, buf, sep, GotPP, GotAP, GotScF, Perr);
+                     PreParamFile, buf, sep, GotAP, GotScF, Perr);
 
     ///// END Read in command line arguments
 
@@ -324,10 +329,6 @@ int _main(int argc, const char* argv[])
 	//// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// ****
 	SetupThreads();
 
-	if (!GotPP)
-	{
-		sprintf(PreParamFile, ".." DIRECTORY_SEPARATOR "Pre_%s", ParamFile);
-	}
 
 	//// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// **** //// ****
 	//// **** READ IN PARAMETERS, DATA ETC.

--- a/src/CovidSim.cpp
+++ b/src/CovidSim.cpp
@@ -113,14 +113,14 @@ int PlaceDistDistrib[NUM_PLACE_TYPES][MAX_DIST], PlaceSizeDistrib[NUM_PLACE_TYPE
 void
 ParseCmdLineArgs(int argc, const char** argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
-                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i,
+                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep,
                  int &GotPP, int &GotAP, int &GotScF, int &Perr) {
     int GotL = 0, GotS = 0, GotO = 0, GotP = 0;
     if (argc < 7) Perr = 1;
     else
     {
         ///// Get seeds.
-        i = argc - 4;
+        int i = argc - 4;
         sscanf(argv[i], "%li", &P.setupSeed1);
         sscanf(argv[i + 1], "%li", &P.setupSeed2);
         sscanf(argv[i + 2], "%li", &P.runSeed1);
@@ -287,7 +287,7 @@ int _main(int argc, const char* argv[])
 
     ParseCmdLineArgs(argc, argv, ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile,
                      InterventionFile,
-                     PreParamFile, buf, sep, i, GotPP, GotAP, GotScF, Perr);
+                     PreParamFile, buf, sep, GotPP, GotAP, GotScF, Perr);
 
     ///// END Read in command line arguments
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 
-extern int _main(int argc, char* argv[]);
+extern int _main(int argc, const char** argv);
 
-extern int main(int argc, char* argv[]) {
+extern int main(int argc, const char** argv) {
     return _main(argc, argv);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,6 @@
+
+extern int _main(int argc, char* argv[]);
+
+extern int main(int argc, char* argv[]) {
+    return _main(argc, argv);
+}

--- a/src/tests/AdunitConfigBuilder.cpp
+++ b/src/tests/AdunitConfigBuilder.cpp
@@ -55,9 +55,6 @@ East_Midlands	East_of_England	London	North_East	North_West	South_East	South_West
 [Divisor for level 1 administrative units]
 100
 
-[Divisor for countries]
-100000
-
 [Correct administrative unit populations]
 0
 
@@ -175,6 +172,7 @@ std::unique_ptr<ConfigFile> AdunitConfigBuilder::BuildCfgFile(
     addItem("Kernel 4th param for place types", kernelParam4ForPlaces);
     addItem("Household size distribution", householdSizeDist);
     addItem("Correct age distribution after household allocation to exactly match specified demography", correctHouseAgeDistToExactGeography);
+    addItem("Divisor for countries", divisorForCountries);
 
     return std::make_unique<ConfigFile>(fname, buf.str());
 }

--- a/src/tests/AdunitConfigBuilder.cpp
+++ b/src/tests/AdunitConfigBuilder.cpp
@@ -15,11 +15,6 @@ namespace {
 [Administrative unit to seed initial infection into]
 0
 
-
-[Population size]
-66777534
-[ONS pop proj]
-
 [Fix population size at specified value]
 1
 
@@ -185,5 +180,17 @@ East_Midlands	East_of_England	London	North_East	North_West	South_East	South_West
 std::unique_ptr<ConfigFile> AdunitConfigBuilder::BuildCfgFile(
         const std::string& fname) const
 {
-    return std::make_unique<ConfigFile>(fname, defaultContent);
+    std::stringstream buf;
+    buf << defaultContent << std::endl;
+    const auto addItem = [&] (const std::string& name, const std::optional<std::string>& val) {
+        if (val.has_value()) {
+            buf << std::endl;
+            buf << "[" << name << "]" << std::endl;
+            buf << val.value() << std::endl;
+        }
+    };
+    addItem("Population size", populationSize);
+    addItem("Include households", doHouseholds);
+
+    return std::make_unique<ConfigFile>(fname, buf.str());
 }

--- a/src/tests/AdunitConfigBuilder.cpp
+++ b/src/tests/AdunitConfigBuilder.cpp
@@ -1,0 +1,189 @@
+//
+// Created by lhumphreys on 10/05/2020.
+//
+
+#include "AdunitConfigBuilder.h"
+namespace {
+    constexpr const char* const defaultContent = R"CONFIG(
+[Number of seed locations]
+1
+
+[Initial number of infecteds]
+100
+
+
+[Administrative unit to seed initial infection into]
+0
+
+
+[Population size]
+66777534
+[ONS pop proj]
+
+[Fix population size at specified value]
+1
+
+[Number of countries to include]
+1
+
+[List of names of countries to include]
+United_Kingdom
+
+[Number of level 1 administrative units to include]
+0
+
+[List of level 1 administrative units to include]
+East_Midlands	East_of_England	London	North_East	North_West	South_East	South_West	West_Midlands	Yorkshire_and_the_Humber	Northern_Ireland	North_Eastern_Scotland	Highlands_and_Islands	Eastern_Scotland	West_Central_Scotland	Southern_Scotland	East_Wales	West_Wales_and_The_Valleys
+
+[Codes and country/province names for admin units]
+540100	United_Kingdom	East_Midlands
+540200	United_Kingdom	East_of_England
+540300	United_Kingdom	London
+540400	United_Kingdom	North_East
+540500	United_Kingdom	North_West
+540600	United_Kingdom	South_East
+540700	United_Kingdom	South_West
+540800	United_Kingdom	West_Midlands
+540900	United_Kingdom	Yorkshire_and_the_Humber
+541000	United_Kingdom	Northern_Ireland
+541100	United_Kingdom	North_Eastern_Scotland
+541200	United_Kingdom	Highlands_and_Islands
+541300	United_Kingdom	Eastern_Scotland
+541400	United_Kingdom	West_Central_Scotland
+541500	United_Kingdom	Southern_Scotland
+541600	United_Kingdom	East_Wales
+541700	United_Kingdom	West_Wales_and_The_Valleys
+
+[Mask for level 1 administrative units]
+100000
+
+[Divisor for level 1 administrative units]
+100
+
+[Divisor for countries]
+100000
+
+[Correct administrative unit populations]
+0
+
+[Age distribution of population]
+0.057810002	0.060683584	0.05827917	0.054298865	0.060021798	0.066052894	0.069334292	0.067586774	0.06346124	0.063284341	0.068269448	0.066860984	0.057523138	0.04981529	0.049914383	0.035974234	0.050829564
+[ONS proj for 2020]
+
+
+[Household size distribution]
+0.305305	0.342342	0.159159	0.136136	0.040040	0.011243	0.003677	0.001256	0.000453	0.000388
+(ONS 2020 with IPUMS and national statistics)
+
+[Correct age distribution after household allocation to exactly match specified demography]
+1
+
+[Include places]
+1
+
+[Place overlap matrix]
+1 0 0 0
+0 1 0 0
+0 0 1 0
+0 0 0 1
+
+(note this isn't used - currently assume identity matrix)
+
+[Number of types of places]
+4
+
+[Proportion of age group 1 in place types]
+0.976396125	0.98390173	0	0.37097869299999997
+
+[Minimum age for age group 1 in place types]
+5	11	18	16
+
+[Maximum age for age group 1 in place types]
+11	16	65	18
+
+[Proportion of age group 2 in place types]
+1	0.959727307	0.629021307	0.040272693000000026
+
+[Minimum age for age group 2 in place types]
+3	16	18	18
+
+[Maximum age for age group 2 in place types]
+5	18	21	21
+
+[Proportion of age group 3 in place types]
+0.005292966	0.006331515	0.064144615	0.742058813
+
+[Minimum age for age group 3 in place types]
+21	21	21	21
+
+[Maximum age for age group 3 in place types]
+65	65	65	65
+
+[Kernel shape params for place types]
+3 3 3 3
+
+
+[Kernel scale params for place types]
+4000  4000  4000  4000
+
+[Mean size of place types]
+230 1010  3300  14.28
+
+(inc teachers)
+
+[Number of closest places people pick from (0=all) for place types]
+3 3 6 0
+
+[Param 1 of place group size distribution]
+25  25  100 10
+
+[Power of place size distribution]
+0 0 0 1.34
+
+[Offset of place size distribution]
+0 0 0 5.35
+
+[Maximum of place size distribution]
+0 0 0 5927
+
+[Kernel type]
+2
+
+[Kernel scale]
+4000
+
+[Kernel Shape]
+3
+
+[Kernel resolution]
+2000000
+
+[Kernel higher resolution factor]
+400
+
+===================================
+[Include holidays]
+1
+
+[Proportion of places remaining open during holidays by place type]
+0 0 1 1
+
+[Number of holidays]
+9
+
+[Holiday start times]
+97	195	294	353	412	461	559	658	717
+
+
+[Holiday durations]
+15	51	7	15	7	15	51	7	15
+
+===================================
+)CONFIG";
+}
+
+std::unique_ptr<ConfigFile> AdunitConfigBuilder::BuildCfgFile(
+        const std::string& fname) const
+{
+    return std::make_unique<ConfigFile>(fname, defaultContent);
+}

--- a/src/tests/AdunitConfigBuilder.cpp
+++ b/src/tests/AdunitConfigBuilder.cpp
@@ -65,14 +65,6 @@ East_Midlands	East_of_England	London	North_East	North_West	South_East	South_West
 0.057810002	0.060683584	0.05827917	0.054298865	0.060021798	0.066052894	0.069334292	0.067586774	0.06346124	0.063284341	0.068269448	0.066860984	0.057523138	0.04981529	0.049914383	0.035974234	0.050829564
 [ONS proj for 2020]
 
-
-[Household size distribution]
-0.305305	0.342342	0.159159	0.136136	0.040040	0.011243	0.003677	0.001256	0.000453	0.000388
-(ONS 2020 with IPUMS and national statistics)
-
-[Correct age distribution after household allocation to exactly match specified demography]
-1
-
 [Include places]
 1
 
@@ -181,6 +173,8 @@ std::unique_ptr<ConfigFile> AdunitConfigBuilder::BuildCfgFile(
     addItem("Kernel type for place types", kernelTypeForPlaces);
     addItem("Kernel 3rd param for place types", kernelParam3ForPlaces);
     addItem("Kernel 4th param for place types", kernelParam4ForPlaces);
+    addItem("Household size distribution", householdSizeDist);
+    addItem("Correct age distribution after household allocation to exactly match specified demography", correctHouseAgeDistToExactGeography);
 
     return std::make_unique<ConfigFile>(fname, buf.str());
 }

--- a/src/tests/AdunitConfigBuilder.cpp
+++ b/src/tests/AdunitConfigBuilder.cpp
@@ -114,13 +114,6 @@ East_Midlands	East_of_England	London	North_East	North_West	South_East	South_West
 [Maximum age for age group 3 in place types]
 65	65	65	65
 
-[Kernel shape params for place types]
-3 3 3 3
-
-
-[Kernel scale params for place types]
-4000  4000  4000  4000
-
 [Mean size of place types]
 230 1010  3300  14.28
 
@@ -140,21 +133,6 @@ East_Midlands	East_of_England	London	North_East	North_West	South_East	South_West
 
 [Maximum of place size distribution]
 0 0 0 5927
-
-[Kernel type]
-2
-
-[Kernel scale]
-4000
-
-[Kernel Shape]
-3
-
-[Kernel resolution]
-2000000
-
-[Kernel higher resolution factor]
-400
 
 ===================================
 [Include holidays]
@@ -191,6 +169,18 @@ std::unique_ptr<ConfigFile> AdunitConfigBuilder::BuildCfgFile(
     };
     addItem("Population size", populationSize);
     addItem("Include households", doHouseholds);
+    addItem("Kernel type", kernelType);
+    addItem("Kernel scale", kernelScale);
+    addItem("Kernel Shape", kernelShape);
+    addItem("Kernel resolution", kernelResolution);
+    addItem("Kernel higher resolution factor", kernelHigherResolutionFactor);
+    addItem("Kernel 3rd param", kernelParam3);
+    addItem("Kernel 4th param", kernelParam4);
+    addItem("Kernel shape params for place types", kernelShapeParamForPlaces);
+    addItem("Kernel scale params for place types", kernelScaleParamForPlaces);
+    addItem("Kernel type for place types", kernelTypeForPlaces);
+    addItem("Kernel 3rd param for place types", kernelParam3ForPlaces);
+    addItem("Kernel 4th param for place types", kernelParam4ForPlaces);
 
     return std::make_unique<ConfigFile>(fname, buf.str());
 }

--- a/src/tests/AdunitConfigBuilder.h
+++ b/src/tests/AdunitConfigBuilder.h
@@ -1,0 +1,17 @@
+//
+// Created by lhumphreys on 10/05/2020.
+//
+
+#ifndef COVIDTEST_ADUNITCONFIGBUILDER_H
+#define COVIDTEST_ADUNITCONFIGBUILDER_H
+#include <memory>
+#include "ConfigFile.h"
+
+
+class AdunitConfigBuilder {
+public:
+    std::unique_ptr<ConfigFile> BuildCfgFile(const std::string& fname = "admin.txt") const;
+};
+
+
+#endif //COVIDTEST_ADUNITCONFIGBUILDER_H

--- a/src/tests/AdunitConfigBuilder.h
+++ b/src/tests/AdunitConfigBuilder.h
@@ -12,6 +12,20 @@
 struct AdunitConfigBuilder {
     std::optional<std::string> populationSize = "66777534";
     std::optional<std::string> doHouseholds;
+
+    std::optional<std::string> kernelType = "2";
+    std::optional<std::string> kernelScale = "4000";
+    std::optional<std::string> kernelShape = "3";
+    std::optional<std::string> kernelResolution = "2000000";
+    std::optional<std::string> kernelHigherResolutionFactor = "40";
+    std::optional<std::string> kernelParam3;
+    std::optional<std::string> kernelParam4;
+    std::optional<std::string> kernelShapeParamForPlaces = "3 3 3 3";
+    std::optional<std::string> kernelScaleParamForPlaces = "4000 4000 4000 4000";
+    std::optional<std::string> kernelTypeForPlaces;
+    std::optional<std::string> kernelParam3ForPlaces;
+    std::optional<std::string> kernelParam4ForPlaces;
+
     std::unique_ptr<ConfigFile> BuildCfgFile(const std::string& fname = "admin.txt") const;
 };
 

--- a/src/tests/AdunitConfigBuilder.h
+++ b/src/tests/AdunitConfigBuilder.h
@@ -11,7 +11,6 @@
 
 struct AdunitConfigBuilder {
     std::optional<std::string> populationSize = "66777534";
-    std::optional<std::string> doHouseholds;
 
     std::optional<std::string> kernelType = "2";
     std::optional<std::string> kernelScale = "4000";
@@ -25,6 +24,10 @@ struct AdunitConfigBuilder {
     std::optional<std::string> kernelTypeForPlaces;
     std::optional<std::string> kernelParam3ForPlaces;
     std::optional<std::string> kernelParam4ForPlaces;
+
+    std::optional<std::string> doHouseholds;
+    std::optional<std::string> householdSizeDist = "0.305305	0.342342	0.159159	0.136136	0.040040	0.011243	0.003677	0.001256	0.000453	0.000388";
+    std::optional<std::string> correctHouseAgeDistToExactGeography = "1";
 
     std::unique_ptr<ConfigFile> BuildCfgFile(const std::string& fname = "admin.txt") const;
 };

--- a/src/tests/AdunitConfigBuilder.h
+++ b/src/tests/AdunitConfigBuilder.h
@@ -5,11 +5,13 @@
 #ifndef COVIDTEST_ADUNITCONFIGBUILDER_H
 #define COVIDTEST_ADUNITCONFIGBUILDER_H
 #include <memory>
+#include <optional>
 #include "ConfigFile.h"
 
 
-class AdunitConfigBuilder {
-public:
+struct AdunitConfigBuilder {
+    std::optional<std::string> populationSize = "66777534";
+    std::optional<std::string> doHouseholds;
     std::unique_ptr<ConfigFile> BuildCfgFile(const std::string& fname = "admin.txt") const;
 };
 

--- a/src/tests/AdunitConfigBuilder.h
+++ b/src/tests/AdunitConfigBuilder.h
@@ -29,6 +29,9 @@ struct AdunitConfigBuilder {
     std::optional<std::string> householdSizeDist = "0.305305	0.342342	0.159159	0.136136	0.040040	0.011243	0.003677	0.001256	0.000453	0.000388";
     std::optional<std::string> correctHouseAgeDistToExactGeography = "1";
 
+    std::optional<std::string> divisorForCountries = "100000";
+
+
     std::unique_ptr<ConfigFile> BuildCfgFile(const std::string& fname = "admin.txt") const;
 };
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -20,7 +20,6 @@ add_library(CovidSim
             ../CovidSim.h
             ../Dist.cpp
             ../Dist.h
-            ../Error.cpp
             ../Error.h
             ../InfStat.h
             ../Kernels.cpp
@@ -38,6 +37,7 @@ add_library(CovidSim
             ../Sweep.h
             ../Update.cpp
             ../Update.h
+		    testError.cpp
 	    )
 
 option(USE_OPENMP "Compile with OpenMP parallelism enabled" ON)
@@ -47,12 +47,26 @@ target_include_directories(CovidSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(CovidSim PUBLIC OpenMP::OpenMP_CXX)
 
 add_library(CovidSimTest
+		ConfigFile.cpp
+		ConfigFile.h
+		CovidSimCmdLineArgs.cpp
+		CovidSimCmdLineArgs.h
+		CovidSimExternInterface.h
 		CovidSimTestFixture.cpp
-		CovidSimTestFixture.h CovidSimCmdLineArgs.cpp CovidSimCmdLineArgs.h)
+		CovidSimTestFixture.h
+		ParamsConfigBuilder.cpp
+		ParamsConfigBuilder.h
+		PreParamConfigBuilder.cpp
+		PreParamConfigBuilder.h
+		AdunitConfigBuilder.cpp AdunitConfigBuilder.h)
 target_link_libraries(CovidSimTest PUBLIC CovidSim GTest::GTest)
 
 add_executable(testCommandLineParsing testCommandLineParsing.cpp)
 target_link_libraries(testCommandLineParsing CovidSim CovidSimTest GTest::GTest GTest::Main)
 
+add_executable(testParamParsing testParamParsing.cpp)
+target_link_libraries(testParamParsing CovidSim CovidSimTest GTest::GTest GTest::Main)
+
 enable_testing()
 add_test(testCommandLineParsing testCommandLineParsing)
+add_test(testParamParsing testParamParsing)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -40,15 +40,19 @@ add_library(CovidSim
             ../Update.h
 	    )
 
-
 option(USE_OPENMP "Compile with OpenMP parallelism enabled" ON)
 target_compile_features(CovidSim PUBLIC cxx_std_17)
 target_compile_definitions(CovidSim PUBLIC UNIX)
 target_include_directories(CovidSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(CovidSim PUBLIC OpenMP::OpenMP_CXX)
 
+add_library(CovidSimTest
+		CovidSimTestFixture.cpp
+		CovidSimTestFixture.h CovidSimCmdLineArgs.cpp CovidSimCmdLineArgs.h)
+target_link_libraries(CovidSimTest PUBLIC CovidSim GTest::GTest)
+
 add_executable(paramRead paramReadTests.cpp)
-target_link_libraries(paramRead CovidSim GTest::GTest GTest::Main)
+target_link_libraries(paramRead CovidSim CovidSimTest GTest::GTest GTest::Main)
 
 enable_testing()
 add_test(paramRead paramRead)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -51,8 +51,8 @@ add_library(CovidSimTest
 		CovidSimTestFixture.h CovidSimCmdLineArgs.cpp CovidSimCmdLineArgs.h)
 target_link_libraries(CovidSimTest PUBLIC CovidSim GTest::GTest)
 
-add_executable(paramRead paramReadTests.cpp)
-target_link_libraries(paramRead CovidSim CovidSimTest GTest::GTest GTest::Main)
+add_executable(testCommandLineParsing testCommandLineParsing.cpp)
+target_link_libraries(testCommandLineParsing CovidSim CovidSimTest GTest::GTest GTest::Main)
 
 enable_testing()
-add_test(paramRead paramRead)
+add_test(testCommandLineParsing testCommandLineParsing)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,0 +1,54 @@
+project(CovidTest)
+
+# Match the core CMake file
+cmake_minimum_required (VERSION 3.8)
+
+find_package(OpenMP REQUIRED)
+find_package(GTest REQUIRED)
+
+
+add_library(CovidSim
+            ../binio.cpp
+            ../binio.h
+            ../Bitmap.cpp
+            ../Bitmap.h
+            ../CalcInfSusc.cpp
+            ../CalcInfSusc.h
+            ../Constants.h
+            ../Country.h
+            ../CovidSim.cpp
+            ../CovidSim.h
+            ../Dist.cpp
+            ../Dist.h
+            ../Error.cpp
+            ../Error.h
+            ../InfStat.h
+            ../Kernels.cpp
+            ../Kernels.h
+            ../MachineDefines.h
+            ../Model.h
+            ../ModelMacros.h
+            ../Param.h
+            ../Rand.cpp
+            ../Rand.h
+            ../SetupModel.cpp
+            ../SetupModel.h
+            ../SharedFuncs.h
+            ../Sweep.cpp
+            ../Sweep.h
+            ../Update.cpp
+            ../Update.h
+	    )
+
+
+option(USE_OPENMP "Compile with OpenMP parallelism enabled" ON)
+target_compile_features(CovidSim PUBLIC cxx_std_17)
+target_compile_definitions(CovidSim PUBLIC UNIX)
+target_include_directories(CovidSim PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(CovidSim PUBLIC OpenMP::OpenMP_CXX)
+
+add_executable(paramRead paramReadTests.cpp)
+target_link_libraries(paramRead CovidSim GTest::GTest GTest::Main)
+
+enable_testing()
+add_test(paramRead paramRead)

--- a/src/tests/ConfigFile.cpp
+++ b/src/tests/ConfigFile.cpp
@@ -1,0 +1,23 @@
+//
+// Created by lhumphreys on 09/05/2020.
+//
+
+#include "ConfigFile.h"
+#include <fstream>
+
+ConfigFile::ConfigFile(const std::string &fname, const std::string &content)
+    : filepath(std::filesystem::absolute(fname))
+{
+    std::ofstream fileToWrite;
+    fileToWrite.open(AbsolutePath(), std::ofstream::trunc);
+    fileToWrite << content;
+    fileToWrite.close();
+}
+
+ConfigFile::~ConfigFile() {
+    std::filesystem::remove(filepath);
+}
+
+const char* const ConfigFile::AbsolutePath() const {
+    return filepath.c_str();
+}

--- a/src/tests/ConfigFile.h
+++ b/src/tests/ConfigFile.h
@@ -1,0 +1,23 @@
+//
+// Created by lhumphreys on 09/05/2020.
+//
+
+#ifndef COVIDTEST_CONFIGFILE_H
+#define COVIDTEST_CONFIGFILE_H
+#include <string>
+#include <filesystem>
+
+class ConfigFile {
+public:
+    ConfigFile(const std::string& fname, const std::string& content);
+    virtual ~ConfigFile();
+
+    const char* const AbsolutePath() const;
+
+private:
+    std::filesystem::path filepath;
+
+};
+
+
+#endif //COVIDTEST_CONFIGFILE_H

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -10,7 +10,6 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
             "/PP:preUK_R0=2.0.txt",
             "/CLP1:100000",
             "/CLP2:0",
-            "/O:NoInt_R0=2.2",
             "/D:wpop_file",
             "/M:wpop_bin",
             "/A:sample_admin.txt",
@@ -21,11 +20,12 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
             args.push_back(std::string("/") + argSwitch + ":" + argField.value());
         }
     };
+    addOptionalArg("AP", airTravelFile);
     addOptionalArg("C", placeCloseIndepThreshold);
     addOptionalArg("L", networkFileToLoad);
-    addOptionalArg("S", networkFileToSave);
-    addOptionalArg("AP", airTravelFile);
+    addOptionalArg("O", outFileBasePath);
     addOptionalArg("P", paramFile);
+    addOptionalArg("S", networkFileToSave);
 
     args.push_back(setupSeeds[0]);
     args.push_back(setupSeeds[1]);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -8,7 +8,6 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     std::vector<std::string> args ={
             "CovidSim",
             "/PP:preUK_R0=2.0.txt",
-            "/P:p_NoInt.txt",
             "/CLP1:100000",
             "/CLP2:0",
             "/O:NoInt_R0=2.2",
@@ -26,6 +25,7 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     addOptionalArg("L", networkFileToLoad);
     addOptionalArg("S", networkFileToSave);
     addOptionalArg("AP", airTravelFile);
+    addOptionalArg("P", paramFile);
 
     args.push_back(setupSeeds[0]);
     args.push_back(setupSeeds[1]);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -8,7 +8,6 @@
 std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     std::vector<std::string> args ={
             "CovidSim",
-            "/D:wpop_file",
             "/M:wpop_bin",
             "/A:sample_admin.txt",
             "/R:1.1"
@@ -18,6 +17,7 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
             args.push_back(std::string("/") + argSwitch + ":" + argField.value());
         }
     };
+    addOptionalArg("D", densityFile);
     addOptionalArg("AP", airTravelFile);
     addOptionalArg("C", placeCloseIndepThreshold);
     addOptionalArg("L", networkFileToLoad);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -7,7 +7,6 @@
 std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     std::vector<std::string> args ={
             "CovidSim",
-            "/PP:preUK_R0=2.0.txt",
             "/CLP1:100000",
             "/CLP2:0",
             "/D:wpop_file",
@@ -25,6 +24,7 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     addOptionalArg("L", networkFileToLoad);
     addOptionalArg("O", outFileBasePath);
     addOptionalArg("P", paramFile);
+    addOptionalArg("PP", preParamFile);
     addOptionalArg("S", networkFileToSave);
 
     args.push_back(setupSeeds[0]);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -6,7 +6,7 @@
 
 std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     std::vector<std::string> args ={
-            "/C:1",
+            "CovidSim",
             "/PP:preUK_R0=2.0.txt",
             "/P:p_NoInt.txt",
             "/CLP1:100000",
@@ -18,6 +18,9 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
             "/S:NetworkUKN_32T_100th.bin",
             "/R:1.1"
     };
+    if (placeCloseIndepThreshold.has_value()) {
+        args.push_back(std::string("/C:") + placeCloseIndepThreshold.value());
+    }
     args.push_back(setupSeeds[0]);
     args.push_back(setupSeeds[1]);
     args.push_back(runSeeds[0]);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -8,7 +8,6 @@
 std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     std::vector<std::string> args ={
             "CovidSim",
-            "/A:sample_admin.txt",
             "/R:1.1"
     };
     const auto addOptionalArg = [&](const std::string& argSwitch, const std::optional<std::string>& argField) -> void {
@@ -16,9 +15,10 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
             args.push_back(std::string("/") + argSwitch + ":" + argField.value());
         }
     };
-    addOptionalArg("D", densityFile);
+    addOptionalArg("A", adminFile);
     addOptionalArg("AP", airTravelFile);
     addOptionalArg("C", placeCloseIndepThreshold);
+    addOptionalArg("D", densityFile);
     addOptionalArg("L", networkFileToLoad);
     addOptionalArg("M", densityOutputFile);
     addOptionalArg("O", outFileBasePath);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -26,6 +26,8 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     addOptionalArg("PP", preParamFile);
     addOptionalArg("R", r0);
     addOptionalArg("S", networkFileToSave);
+    addOptionalArg("KO", kernelOffsetScale);
+    addOptionalArg("KP", kernelPowerScale);
 
     std::stringstream paramName;
     for (size_t i = 0; i < NUM_CMD_LINE_PARAMS; ++i) {

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -7,8 +7,7 @@
 
 std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     std::vector<std::string> args ={
-            "CovidSim",
-            "/R:1.1"
+            "CovidSim"
     };
     const auto addOptionalArg = [&](const std::string& argSwitch, const std::optional<std::string>& argField) -> void {
         if (argField.has_value()) {
@@ -24,6 +23,7 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     addOptionalArg("O", outFileBasePath);
     addOptionalArg("P", paramFile);
     addOptionalArg("PP", preParamFile);
+    addOptionalArg("R", r0);
     addOptionalArg("S", networkFileToSave);
 
     std::stringstream paramName;

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -8,7 +8,6 @@
 std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     std::vector<std::string> args ={
             "CovidSim",
-            "/M:wpop_bin",
             "/A:sample_admin.txt",
             "/R:1.1"
     };
@@ -21,6 +20,7 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     addOptionalArg("AP", airTravelFile);
     addOptionalArg("C", placeCloseIndepThreshold);
     addOptionalArg("L", networkFileToLoad);
+    addOptionalArg("M", densityOutputFile);
     addOptionalArg("O", outFileBasePath);
     addOptionalArg("P", paramFile);
     addOptionalArg("PP", preParamFile);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -25,6 +25,7 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     addOptionalArg("C", placeCloseIndepThreshold);
     addOptionalArg("L", networkFileToLoad);
     addOptionalArg("S", networkFileToSave);
+    addOptionalArg("AP", airTravelFile);
 
     args.push_back(setupSeeds[0]);
     args.push_back(setupSeeds[1]);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -3,12 +3,11 @@
 //
 
 #include "CovidSimCmdLineArgs.h"
+#include <sstream>
 
 std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     std::vector<std::string> args ={
             "CovidSim",
-            "/CLP1:100000",
-            "/CLP2:0",
             "/D:wpop_file",
             "/M:wpop_bin",
             "/A:sample_admin.txt",
@@ -26,6 +25,13 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     addOptionalArg("P", paramFile);
     addOptionalArg("PP", preParamFile);
     addOptionalArg("S", networkFileToSave);
+
+    std::stringstream paramName;
+    for (size_t i = 0; i < NUM_CMD_LINE_PARAMS; ++i) {
+        paramName.str("");
+        paramName << "CLP" << (i+1);
+        addOptionalArg(paramName.str(), cmdLineParam[i]);
+    }
 
     args.push_back(setupSeeds[0]);
     args.push_back(setupSeeds[1]);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -16,6 +16,7 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
     };
     addOptionalArg("A", adminFile);
     addOptionalArg("AP", airTravelFile);
+    addOptionalArg("c", maxThreads);
     addOptionalArg("C", placeCloseIndepThreshold);
     addOptionalArg("D", densityFile);
     addOptionalArg("L", networkFileToLoad);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -15,12 +15,17 @@ std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
             "/D:wpop_file",
             "/M:wpop_bin",
             "/A:sample_admin.txt",
-            "/S:NetworkUKN_32T_100th.bin",
             "/R:1.1"
     };
-    if (placeCloseIndepThreshold.has_value()) {
-        args.push_back(std::string("/C:") + placeCloseIndepThreshold.value());
-    }
+    const auto addOptionalArg = [&](const std::string& argSwitch, const std::optional<std::string>& argField) -> void {
+        if (argField.has_value()) {
+            args.push_back(std::string("/") + argSwitch + ":" + argField.value());
+        }
+    };
+    addOptionalArg("C", placeCloseIndepThreshold);
+    addOptionalArg("L", networkFileToLoad);
+    addOptionalArg("S", networkFileToSave);
+
     args.push_back(setupSeeds[0]);
     args.push_back(setupSeeds[1]);
     args.push_back(runSeeds[0]);

--- a/src/tests/CovidSimCmdLineArgs.cpp
+++ b/src/tests/CovidSimCmdLineArgs.cpp
@@ -1,0 +1,27 @@
+//
+// Created by lhumphreys on 09/05/2020.
+//
+
+#include "CovidSimCmdLineArgs.h"
+
+std::vector<std::string> CovidSimCmdLineArgs::BuildCmdLine() const {
+    std::vector<std::string> args ={
+            "/C:1",
+            "/PP:preUK_R0=2.0.txt",
+            "/P:p_NoInt.txt",
+            "/CLP1:100000",
+            "/CLP2:0",
+            "/O:NoInt_R0=2.2",
+            "/D:wpop_file",
+            "/M:wpop_bin",
+            "/A:sample_admin.txt",
+            "/S:NetworkUKN_32T_100th.bin",
+            "/R:1.1"
+    };
+    args.push_back(setupSeeds[0]);
+    args.push_back(setupSeeds[1]);
+    args.push_back(runSeeds[0]);
+    args.push_back(runSeeds[1]);
+
+    return args;
+}

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -5,9 +5,11 @@
 #include <optional>
 
 struct CovidSimCmdLineArgs {
+    std::optional<std::string> networkFileToLoad;
+    std::optional<std::string> networkFileToSave;
     std::optional<std::string> placeCloseIndepThreshold;
-    std::string setupSeeds[2] = {"98798150", "729101"};
     std::string runSeeds[2] = {"17389101", "4797132"};
+    std::string setupSeeds[2] = {"98798150", "729101"};
     [[nodiscard]] std::vector<std::string> BuildCmdLine() const;
 };
 

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -8,6 +8,7 @@ struct CovidSimCmdLineArgs {
     std::optional<std::string> airTravelFile;
     std::optional<std::string> networkFileToLoad;
     std::optional<std::string> networkFileToSave;
+    std::optional<std::string> paramFile = "paramFile.txt";
     std::optional<std::string> placeCloseIndepThreshold;
 
     std::string runSeeds[2] = {"17389101", "4797132"};

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -9,6 +9,7 @@ struct CovidSimCmdLineArgs {
 
     std::optional<std::string> airTravelFile;
     std::optional<std::string> cmdLineParam[NUM_CMD_LINE_PARAMS];
+    std::optional<std::string> densityFile;
     std::optional<std::string> networkFileToLoad;
     std::optional<std::string> networkFileToSave;
     std::optional<std::string> outFileBasePath = "results_";

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -7,6 +7,7 @@
 struct CovidSimCmdLineArgs {
     static constexpr size_t NUM_CMD_LINE_PARAMS = 6;
 
+    std::optional<std::string> adminFile;
     std::optional<std::string> airTravelFile;
     std::optional<std::string> cmdLineParam[NUM_CMD_LINE_PARAMS];
     std::optional<std::string> densityFile;

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -8,6 +8,7 @@ struct CovidSimCmdLineArgs {
     std::optional<std::string> airTravelFile;
     std::optional<std::string> networkFileToLoad;
     std::optional<std::string> networkFileToSave;
+    std::optional<std::string> outFileBasePath = "results_";
     std::optional<std::string> paramFile = "paramFile.txt";
     std::optional<std::string> placeCloseIndepThreshold;
 

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -2,8 +2,10 @@
 #define COVIDTEST_COVIDSIMCMDLINEARGS_H
 #include <string>
 #include <vector>
+#include <optional>
 
 struct CovidSimCmdLineArgs {
+    std::optional<std::string> placeCloseIndepThreshold;
     std::string setupSeeds[2] = {"98798150", "729101"};
     std::string runSeeds[2] = {"17389101", "4797132"};
     [[nodiscard]] std::vector<std::string> BuildCmdLine() const;

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -5,9 +5,11 @@
 #include <optional>
 
 struct CovidSimCmdLineArgs {
+    std::optional<std::string> airTravelFile;
     std::optional<std::string> networkFileToLoad;
     std::optional<std::string> networkFileToSave;
     std::optional<std::string> placeCloseIndepThreshold;
+
     std::string runSeeds[2] = {"17389101", "4797132"};
     std::string setupSeeds[2] = {"98798150", "729101"};
     [[nodiscard]] std::vector<std::string> BuildCmdLine() const;

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -12,6 +12,7 @@ struct CovidSimCmdLineArgs {
     std::optional<std::string> cmdLineParam[NUM_CMD_LINE_PARAMS];
     std::optional<std::string> densityFile;
     std::optional<std::string> densityOutputFile;
+    std::optional<std::string> maxThreads;
     std::optional<std::string> networkFileToLoad;
     std::optional<std::string> networkFileToSave;
     std::optional<std::string> outFileBasePath = "results_";

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -10,6 +10,7 @@ struct CovidSimCmdLineArgs {
     std::optional<std::string> networkFileToSave;
     std::optional<std::string> outFileBasePath = "results_";
     std::optional<std::string> paramFile = "paramFile.txt";
+    std::optional<std::string> preParamFile;
     std::optional<std::string> placeCloseIndepThreshold;
 
     std::string runSeeds[2] = {"17389101", "4797132"};

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -20,6 +20,8 @@ struct CovidSimCmdLineArgs {
     std::optional<std::string> preParamFile;
     std::optional<std::string> placeCloseIndepThreshold;
     std::optional<std::string> r0;
+    std::optional<std::string> kernelOffsetScale;
+    std::optional<std::string> kernelPowerScale;
 
     std::string runSeeds[2] = {"17389101", "4797132"};
     std::string setupSeeds[2] = {"98798150", "729101"};

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -10,6 +10,7 @@ struct CovidSimCmdLineArgs {
     std::optional<std::string> airTravelFile;
     std::optional<std::string> cmdLineParam[NUM_CMD_LINE_PARAMS];
     std::optional<std::string> densityFile;
+    std::optional<std::string> densityOutputFile;
     std::optional<std::string> networkFileToLoad;
     std::optional<std::string> networkFileToSave;
     std::optional<std::string> outFileBasePath = "results_";

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -18,6 +18,7 @@ struct CovidSimCmdLineArgs {
     std::optional<std::string> paramFile = "paramFile.txt";
     std::optional<std::string> preParamFile;
     std::optional<std::string> placeCloseIndepThreshold;
+    std::optional<std::string> r0;
 
     std::string runSeeds[2] = {"17389101", "4797132"};
     std::string setupSeeds[2] = {"98798150", "729101"};

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -1,0 +1,13 @@
+#ifndef COVIDTEST_COVIDSIMCMDLINEARGS_H
+#define COVIDTEST_COVIDSIMCMDLINEARGS_H
+#include <string>
+#include <vector>
+
+struct CovidSimCmdLineArgs {
+    std::string setupSeeds[2] = {"98798150", "729101"};
+    std::string runSeeds[2] = {"17389101", "4797132"};
+    [[nodiscard]] std::vector<std::string> BuildCmdLine() const;
+};
+
+
+#endif //COVIDTEST_COVIDSIMCMDLINEARGS_H

--- a/src/tests/CovidSimCmdLineArgs.h
+++ b/src/tests/CovidSimCmdLineArgs.h
@@ -5,7 +5,10 @@
 #include <optional>
 
 struct CovidSimCmdLineArgs {
+    static constexpr size_t NUM_CMD_LINE_PARAMS = 6;
+
     std::optional<std::string> airTravelFile;
+    std::optional<std::string> cmdLineParam[NUM_CMD_LINE_PARAMS];
     std::optional<std::string> networkFileToLoad;
     std::optional<std::string> networkFileToSave;
     std::optional<std::string> outFileBasePath = "results_";

--- a/src/tests/CovidSimExternInterface.h
+++ b/src/tests/CovidSimExternInterface.h
@@ -1,0 +1,35 @@
+#ifndef COVIDTEST_COVIDSIMEXTERNINTERFACE_H
+#define COVIDTEST_COVIDSIMEXTERNINTERFACE_H
+
+#include <Param.h>
+
+/*
+ * CovidSim.cpp was not written to be unit tested, and instead was written as an "all in one"
+ * main file.
+ *
+ * In order to unit test we have to:
+ *   - Rename the main() function - there can only be one in the application
+ *   - Treat it like a library file - and create a header file that allows us to link into it
+ */
+
+void ParseCmdLineArgs(int argc, const char **argv, char *ParamFile, char *DensityFile, char *NetworkFile,
+                      char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
+                      char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep,
+                      int &GotAP, int &GotScF, int &Perr);
+void SetupThreads();
+
+void ReadParams(char* ParamFile, char* PreParamFile);
+
+/**
+ * NOTE: Linking order is important here
+ *
+ * The object file that includes this inherited must be linked into the target binary
+ * *after* CovidSIm.cpp itself so that they reference CovidSim's variables, and not its own
+ */
+extern char OutDensFile[1024];
+extern char OutFileBase[1024];
+extern char OutFile[1024];
+extern param P;
+extern char AdunitFile[1024];
+
+#endif //COVIDTEST_COVIDSIMEXTERNINTERFACE_H

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -1,11 +1,6 @@
 #include "CovidSimTestFixture.h"
+#include "CovidSimExternInterface.h"
 
-void ParseCmdLineArgs(int argc, const char **argv, char *ParamFile, char *DensityFile, char *NetworkFile,
-                 char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
-                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep,
-                 int &GotAP, int &GotScF, int &Perr);
-
-void SetupThreads();
 
 void CovidSimTestFixture::CovidSimMainInitialisation() {
     ///// Flags to ensure various parameters have been read; set to false as default.
@@ -29,7 +24,7 @@ void CovidSimTestFixture::SetUp() {
     memset(AdunitFile(), 0, CHAR_BUF_SIZE);
 }
 
-void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) {
+void CovidSimTestFixture::InvokeParseCmdLine(const std::vector<std::string> &args) {
 
     const int argc = args.size();
     std::vector<const char*> argv;
@@ -43,32 +38,31 @@ void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) 
                       buf, sep, GotAP, GotScF, Perr);
 }
 
-extern param P;
 param& CovidSimTestFixture::P() {
     return ::P;
 }
 
-extern char OutFile[1024];
 char* CovidSimTestFixture::OutFile() const {
     return ::OutFile;
 }
 
-extern char OutFileBase[1024];
 char* CovidSimTestFixture::OutFileBase() const {
     return ::OutFileBase;
 }
 
-extern char OutDensFile[1024];
 char *CovidSimTestFixture::OutDensFile() const {
     return ::OutDensFile;
 }
 
-extern char AdunitFile[1024];
 char *CovidSimTestFixture::AdunitFile() const {
     return ::AdunitFile;
 }
 
 void CovidSimTestFixture::InvokeSetupThreads() {
     SetupThreads();
+}
+
+void CovidSimTestFixture::InvokeReadParams() {
+    ReadParams(ParamFile, PreParamFile);
 }
 

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -3,11 +3,11 @@
 void ParseCmdLineArgs(int argc, const char **argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
                  char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i, int GotP,
-                 int GotO, int GotL, int GotS, int &GotPP, int &GotAP, int &GotScF, int &Perr);
+                 int GotO, int &GotPP, int &GotAP, int &GotScF, int &Perr);
 
 void CovidSimTestFixture::CovidSimMainInitialisation() {
     ///// Flags to ensure various parameters have been read; set to false as default.
-    GotP = GotO = GotL = GotS = GotAP = GotScF = GotPP = 0;
+    GotP = GotO = GotAP = GotScF = GotPP = 0;
 
     Perr = 0;
     fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
@@ -29,7 +29,7 @@ void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) 
 
     ParseCmdLineArgs(argc, argv.data(),
                       ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile, InterventionFile, PreParamFile,
-                      buf, sep, i, GotP, GotO, GotL, GotS, GotPP, GotAP, GotScF, Perr);
+                      buf, sep, i, GotP, GotO, GotPP, GotAP, GotScF, Perr);
 }
 
 extern param P;

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -5,6 +5,8 @@ void ParseCmdLineArgs(int argc, const char **argv, char *ParamFile, char *Densit
                  char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep,
                  int &GotPP, int &GotAP, int &GotScF, int &Perr);
 
+void SetupThreads();
+
 void CovidSimTestFixture::CovidSimMainInitialisation() {
     ///// Flags to ensure various parameters have been read; set to false as default.
     GotAP = GotScF = GotPP = 0;
@@ -64,5 +66,9 @@ char *CovidSimTestFixture::OutDensFile() const {
 extern char AdunitFile[1024];
 char *CovidSimTestFixture::AdunitFile() const {
     return ::AdunitFile;
+}
+
+void CovidSimTestFixture::InvokeSetupThreads() {
+    SetupThreads();
 }
 

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -3,11 +3,11 @@
 void ParseCmdLineArgs(int argc, const char **argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
                  char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i,
-                 int GotO, int &GotPP, int &GotAP, int &GotScF, int &Perr);
+                 int &GotPP, int &GotAP, int &GotScF, int &Perr);
 
 void CovidSimTestFixture::CovidSimMainInitialisation() {
     ///// Flags to ensure various parameters have been read; set to false as default.
-    GotO = GotAP = GotScF = GotPP = 0;
+    GotAP = GotScF = GotPP = 0;
 
     Perr = 0;
     fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
@@ -29,12 +29,21 @@ void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) 
 
     ParseCmdLineArgs(argc, argv.data(),
                       ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile, InterventionFile, PreParamFile,
-                      buf, sep, i, GotO, GotPP, GotAP, GotScF, Perr);
+                      buf, sep, i, GotPP, GotAP, GotScF, Perr);
 }
 
 extern param P;
-
 param& CovidSimTestFixture::P() {
     return ::P;
+}
+
+extern char OutFile[1024];
+char* CovidSimTestFixture::OutFile() const {
+    return ::OutFile;
+}
+
+extern char OutFileBase[1024];
+char* CovidSimTestFixture::OutFileBase() const {
+    return ::OutFileBase;
 }
 

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -1,5 +1,6 @@
 #include "CovidSimTestFixture.h"
 #include "CovidSimExternInterface.h"
+#include <regex>
 
 
 void CovidSimTestFixture::CovidSimMainInitialisation() {
@@ -64,5 +65,23 @@ void CovidSimTestFixture::InvokeSetupThreads() {
 
 void CovidSimTestFixture::InvokeReadParams() {
     ReadParams(ParamFile, PreParamFile);
+}
+
+void CovidSimTestFixture::ExpectCriticalError(
+        const std::string& codeText,
+        const std::function<void()> &code,
+        const std::string& containsRegex)
+{
+    try {
+        code();
+        FAIL() << "Expected an exception to to be thrown when parsing: '" << codeText << "'";
+    } catch (const std::exception& e) {
+        const std::regex msgRegex(containsRegex);
+        EXPECT_TRUE(std::regex_search(e.what(), msgRegex))
+            << ">> Exception message:" << std::endl
+            << e.what()
+            << ">> did not contain expected message:" << std::endl
+            << containsRegex;
+    }
 }
 

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -13,8 +13,13 @@ void CovidSimTestFixture::CovidSimMainInitialisation() {
     fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
 }
 
+namespace {
+    param zeroInitialisedParam;
+}
 void CovidSimTestFixture::SetUp() {
     CovidSimMainInitialisation();
+    // Make sure every state starts with P resset to the state it would be in at program start...
+    P() = ::zeroInitialisedParam;
 }
 
 void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) {

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -2,7 +2,7 @@
 
 void ParseCmdLineArgs(int argc, const char **argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
-                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i,
+                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep,
                  int &GotPP, int &GotAP, int &GotScF, int &Perr);
 
 void CovidSimTestFixture::CovidSimMainInitialisation() {
@@ -11,7 +11,6 @@ void CovidSimTestFixture::CovidSimMainInitialisation() {
 
     Perr = 0;
     fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
-    cl = clock();
 }
 
 void CovidSimTestFixture::SetUp() {
@@ -29,7 +28,7 @@ void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) 
 
     ParseCmdLineArgs(argc, argv.data(),
                       ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile, InterventionFile, PreParamFile,
-                      buf, sep, i, GotPP, GotAP, GotScF, Perr);
+                      buf, sep, GotPP, GotAP, GotScF, Perr);
 }
 
 extern param P;

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -1,0 +1,40 @@
+#include "CovidSimTestFixture.h"
+
+void ParseCmdLineArgs(int argc, const char **argv, char *ParamFile, char *DensityFile, char *NetworkFile,
+                 char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
+                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i, int GotP,
+                 int GotO, int GotL, int GotS, int &GotPP, int &GotAP, int &GotScF, int &Perr);
+
+void CovidSimTestFixture::CovidSimMainInitialisation() {
+    ///// Flags to ensure various parameters have been read; set to false as default.
+    GotP = GotO = GotL = GotS = GotAP = GotScF = GotPP = 0;
+
+    Perr = 0;
+    fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
+    cl = clock();
+}
+
+void CovidSimTestFixture::SetUp() {
+    CovidSimMainInitialisation();
+}
+
+void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) {
+
+    const int argc = args.size();
+    std::vector<const char*> argv;
+    argv.resize(args.size());
+    for (size_t i = 0; i < argc; ++i) {
+        argv[i]= args[i].c_str();
+    }
+
+    ParseCmdLineArgs(argc, argv.data(),
+                      ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile, InterventionFile, PreParamFile,
+                      buf, sep, i, GotP, GotO, GotL, GotS, GotPP, GotAP, GotScF, Perr);
+}
+
+extern param P;
+
+param& CovidSimTestFixture::P() {
+    return ::P;
+}
+

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -2,12 +2,12 @@
 
 void ParseCmdLineArgs(int argc, const char **argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
-                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i, int GotP,
+                 char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep, int i,
                  int GotO, int &GotPP, int &GotAP, int &GotScF, int &Perr);
 
 void CovidSimTestFixture::CovidSimMainInitialisation() {
     ///// Flags to ensure various parameters have been read; set to false as default.
-    GotP = GotO = GotAP = GotScF = GotPP = 0;
+    GotO = GotAP = GotScF = GotPP = 0;
 
     Perr = 0;
     fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
@@ -29,7 +29,7 @@ void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) 
 
     ParseCmdLineArgs(argc, argv.data(),
                       ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile, InterventionFile, PreParamFile,
-                      buf, sep, i, GotP, GotO, GotPP, GotAP, GotScF, Perr);
+                      buf, sep, i, GotO, GotPP, GotAP, GotScF, Perr);
 }
 
 extern param P;

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -3,13 +3,13 @@
 void ParseCmdLineArgs(int argc, const char **argv, char *ParamFile, char *DensityFile, char *NetworkFile,
                  char *AirTravelFile, char *SchoolFile, char *RegDemogFile,
                  char InterventionFile[][1024] , char *PreParamFile, char *buf, char *sep,
-                 int &GotPP, int &GotAP, int &GotScF, int &Perr);
+                 int &GotAP, int &GotScF, int &Perr);
 
 void SetupThreads();
 
 void CovidSimTestFixture::CovidSimMainInitialisation() {
     ///// Flags to ensure various parameters have been read; set to false as default.
-    GotAP = GotScF = GotPP = 0;
+    GotAP = GotScF = 0;
 
     Perr = 0;
     fprintf(stderr, "sizeof(int)=%i sizeof(long)=%i sizeof(float)=%i sizeof(double)=%i sizeof(unsigned short int)=%i sizeof(int *)=%i\n", (int)sizeof(int), (int)sizeof(long), (int)sizeof(float), (int)sizeof(double), (int)sizeof(unsigned short int), (int)sizeof(int*));
@@ -40,7 +40,7 @@ void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) 
 
     ParseCmdLineArgs(argc, argv.data(),
                       ParamFile, DensityFile, NetworkFile, AirTravelFile, SchoolFile, RegDemogFile, InterventionFile, PreParamFile,
-                      buf, sep, GotPP, GotAP, GotScF, Perr);
+                      buf, sep, GotAP, GotScF, Perr);
 }
 
 extern param P;

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -14,12 +14,16 @@ void CovidSimTestFixture::CovidSimMainInitialisation() {
 }
 
 namespace {
+    constexpr size_t CHAR_BUF_SIZE = 1024;
     param zeroInitialisedParam;
 }
 void CovidSimTestFixture::SetUp() {
     CovidSimMainInitialisation();
-    // Make sure every state starts with P resset to the state it would be in at program start...
+    // Make sure every tests starts with P resset to the state it would be in at program start...
     P() = ::zeroInitialisedParam;
+    memset(OutDensFile(), 0, CHAR_BUF_SIZE);
+    memset(OutFile(), 0, CHAR_BUF_SIZE);
+    memset(OutFileBase(), 0, CHAR_BUF_SIZE);
 }
 
 void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) {
@@ -49,5 +53,10 @@ char* CovidSimTestFixture::OutFile() const {
 extern char OutFileBase[1024];
 char* CovidSimTestFixture::OutFileBase() const {
     return ::OutFileBase;
+}
+
+extern char OutDensFile[1024];
+char *CovidSimTestFixture::OutDensFile() const {
+    return ::OutDensFile;
 }
 

--- a/src/tests/CovidSimTestFixture.cpp
+++ b/src/tests/CovidSimTestFixture.cpp
@@ -24,6 +24,7 @@ void CovidSimTestFixture::SetUp() {
     memset(OutDensFile(), 0, CHAR_BUF_SIZE);
     memset(OutFile(), 0, CHAR_BUF_SIZE);
     memset(OutFileBase(), 0, CHAR_BUF_SIZE);
+    memset(AdunitFile(), 0, CHAR_BUF_SIZE);
 }
 
 void CovidSimTestFixture::InvokeReadParam(const std::vector<std::string> &args) {
@@ -58,5 +59,10 @@ char* CovidSimTestFixture::OutFileBase() const {
 extern char OutDensFile[1024];
 char *CovidSimTestFixture::OutDensFile() const {
     return ::OutDensFile;
+}
+
+extern char AdunitFile[1024];
+char *CovidSimTestFixture::AdunitFile() const {
+    return ::AdunitFile;
 }
 

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -15,7 +15,7 @@ protected:
     param& P();
     // variable initialised in CovidSImp.cpp:main
     char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
-    int i, GotP, GotPP, GotO, GotL, GotS, GotAP, GotScF, Perr, cl;
+    int i, GotP, GotPP, GotO, GotAP, GotScF, Perr, cl;
 
 private:
     void CovidSimMainInitialisation();

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -10,6 +10,7 @@ private:
 public:
     void SetUp() override;
     void InvokeReadParam(const std::vector<std::string>& args);
+    void InvokeSetupThreads();
 
 protected:
     param& P();

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -13,9 +13,12 @@ public:
 
 protected:
     param& P();
+    char* OutFile() const;
+    char* OutFileBase() const;
+
     // variable initialised in CovidSImp.cpp:main
     char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
-    int i, GotPP, GotO, GotAP, GotScF, Perr, cl;
+    int i, GotPP, GotAP, GotScF, Perr, cl;
 
 private:
     void CovidSimMainInitialisation();

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -4,6 +4,8 @@
 #include <gtest/gtest.h>
 #include "Param.h"
 
+#define EXPECT_CRIT_ERROR(code, containsRegex) ExpectCriticalError(#code, [&] () { code; }, containsRegex);
+
 class CovidSimTestFixture: public ::testing::Test {
 private:
     static constexpr size_t MAXINTFILE=10;
@@ -19,6 +21,10 @@ protected:
     char* OutFileBase() const;
     char* OutDensFile() const;
     char* AdunitFile() const;
+    void ExpectCriticalError(
+            const std::string& codeText,
+            const std::function<void()>& code,
+            const std::string& containsRegex);
 
     // variable initialised in CovidSImp.cpp:main
     char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -16,6 +16,7 @@ protected:
     char* OutFile() const;
     char* OutFileBase() const;
     char* OutDensFile() const;
+    char* AdunitFile() const;
 
     // variable initialised in CovidSImp.cpp:main
     char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -18,7 +18,7 @@ protected:
 
     // variable initialised in CovidSImp.cpp:main
     char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
-    int i, GotPP, GotAP, GotScF, Perr, cl;
+    int GotPP, GotAP, GotScF, Perr;
 
 private:
     void CovidSimMainInitialisation();

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -21,7 +21,7 @@ protected:
 
     // variable initialised in CovidSImp.cpp:main
     char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
-    int GotPP, GotAP, GotScF, Perr;
+    int GotAP, GotScF, Perr;
 
 private:
     void CovidSimMainInitialisation();

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -1,0 +1,26 @@
+#ifndef COVIDTEST_COVIDSIMTESTFIXTURE_H
+#define COVIDTEST_COVIDSIMTESTFIXTURE_H
+
+#include <gtest/gtest.h>
+#include "Param.h"
+
+class CovidSimTestFixture: public ::testing::Test {
+private:
+    static constexpr size_t MAXINTFILE=10;
+public:
+    void SetUp() override;
+    void InvokeReadParam(const std::vector<std::string>& args);
+
+protected:
+    param& P();
+    // variable initialised in CovidSImp.cpp:main
+    char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
+    int i, GotP, GotPP, GotO, GotL, GotS, GotAP, GotScF, Perr, cl;
+
+private:
+    void CovidSimMainInitialisation();
+
+};
+
+
+#endif //COVIDTEST_COVIDSIMTESTFIXTURE_H

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -15,6 +15,7 @@ protected:
     param& P();
     char* OutFile() const;
     char* OutFileBase() const;
+    char* OutDensFile() const;
 
     // variable initialised in CovidSImp.cpp:main
     char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -9,8 +9,9 @@ private:
     static constexpr size_t MAXINTFILE=10;
 public:
     void SetUp() override;
-    void InvokeReadParam(const std::vector<std::string>& args);
+    void InvokeParseCmdLine(const std::vector<std::string>& args);
     void InvokeSetupThreads();
+    void InvokeReadParams();
 
 protected:
     param& P();

--- a/src/tests/CovidSimTestFixture.h
+++ b/src/tests/CovidSimTestFixture.h
@@ -15,7 +15,7 @@ protected:
     param& P();
     // variable initialised in CovidSImp.cpp:main
     char ParamFile[1024]{}, DensityFile[1024]{}, NetworkFile[1024]{}, AirTravelFile[1024]{}, SchoolFile[1024]{}, RegDemogFile[1024]{}, InterventionFile[MAXINTFILE][1024]{}, PreParamFile[1024]{}, buf[2048]{}, * sep;
-    int i, GotP, GotPP, GotO, GotAP, GotScF, Perr, cl;
+    int i, GotPP, GotO, GotAP, GotScF, Perr, cl;
 
 private:
     void CovidSimMainInitialisation();

--- a/src/tests/ParamsConfigBuilder.cpp
+++ b/src/tests/ParamsConfigBuilder.cpp
@@ -1,0 +1,326 @@
+#include "ParamsConfigBuilder.h"
+namespace {
+    constexpr  const char* const defaultContent = R"CONFIG(
+[Include intervention delays by admin unit]
+0
+
+[Vary efficacies over time]
+0
+
+======== PLACE CLOSURE PARAMETERS
+
+[Place closure start time]
+7
+
+[Place closure second start time]
+100000
+
+[Delay to place closure by admin unit]
+1	1	1
+
+[Duration of place closure by admin unit]
+364	364	364
+
+[Place closure in administrative units rather than rings]
+0
+
+[Administrative unit divisor for place closure]
+1
+
+[Place types to close for admin unit closure (0/1 array)]
+1	1	1	0
+
+[Cumulative proportion of place members needing to become sick for admin unit closure]
+1
+
+[Proportion of places in admin unit needing to pass threshold for place closure]
+1
+
+[Delay to start place closure]
+1
+
+[Duration of place closure]
+364
+
+[Proportion of places remaining open after closure by place type]
+0	0	0.25	1
+
+[Relative household contact rate after closure]
+1.5
+
+[Relative spatial contact rate after closure]
+1.25
+
+[Minimum radius for place closure]
+1
+
+[Place closure incidence threshold]
+0
+ ^^ needs to be 0 for global triggers
+
+[Place closure fractional incidence threshold]
+0
+^^ needs to be 0 for global triggers or if abs incidence threshold used
+
+[Trigger incidence per cell for place closure]
+0
+*** ^^^ change this for global too ***
+
+[Number of change times for levels of place closure]
+4
+
+//// Note: numbers here must match "Number of change times for levels of place closure"; that any times listed here that are before "Place closure start time" and after "Duration of place closure" are irrelevant.
+[Change times for levels of place closure]
+0 50 100 150
+
+//// Example below gives schools closing, then opening etc.
+[Proportion of places remaining open after closure by place type over time]
+0	0	0.25	1
+1	1	0.25	1
+0	0	0.25	1
+1	1	0.25	1
+
+[Relative household contact rates over time after place closure]
+1.5 1.5 1.5 1.5
+
+[Relative spatial contact rates over time after place closure]
+1.25 1.25 1.25 1.25
+
+[Place closure incidence threshold over time]
+0 0 0 0
+^^ needs to be 0 for global triggers
+
+[Place closure fractional incidence threshold over time]
+0 0 0 0
+^^ needs to be 0 for global triggers or if abs incidence threshold used
+
+[Trigger incidence per cell for place closure over time]
+0 0 0 0
+*** ^^^ change these for global too ***
+
+//// Note: closure durations longer than interval between change times will be truncated
+[Duration of place closure over time]
+50 50 50 50
+
+
+==================================	HOUSEHOLD QUARANTINE PARAMETERS
+
+[Household quarantine start time]
+6
+
+[Delay to start household quarantine]
+1
+
+[Delay to household quarantine by admin unit]
+1	1	1
+
+[Duration of household quarantine by admin unit]
+364	364	364
+
+[Household quarantine trigger incidence per cell]
+0
+
+[Length of time households are quarantined]
+14
+
+[Duration of household quarantine policy]
+364
+
+[Relative household contact rate after quarantine]
+1.5
+
+[Residual place contacts after household quarantine by place type]
+0.25	0.25	0.25	0.25
+
+[Residual spatial contacts after household quarantine]
+0.25
+
+[Household level compliance with quarantine]
+0.75
+
+[Individual level compliance with quarantine]
+1.0
+
+[Number of change times for levels of household quarantine]
+3
+
+//// Note: numbers here must match "Number of change times for levels of household quarantine"; that any times listed here that are before "Household quarantine start time" and after "Duration of household quarantine policy" are irrelevant.
+[Change times for levels of household quarantine]
+0 31 121
+
+[Relative household contact rates over time after quarantine]
+1.5 1.5 1.5
+
+[Residual place contacts over time after household quarantine by place type]
+0.25	0.25	0.25	0.25
+0.25	0.25	0.25	0.25
+0.25	0.25	0.25	0.25
+
+[Residual spatial contacts over time after household quarantine]
+0.25 0.25 0.25
+
+[Household level compliance with quarantine over time]
+0.75 0.75 0.75
+
+[Individual level compliance with quarantine over time]
+1.0 1.0 1.0
+
+[Household quarantine trigger incidence per cell over time]
+0 0 0
+
+
+===================================		CASE ISOLATION PARAMETERS
+
+[Case isolation start time]
+6
+
+[Delay to case isolation by admin unit]
+1	1	1
+
+[Duration of case isolation by admin unit]
+364	364	364
+
+[Case isolation trigger incidence per cell]
+0
+
+[Proportion of detected cases isolated]
+0.9
+
+[Delay to start case isolation]
+1
+
+///// i.e. for how many days will given case self-isolate? Different from "Duration of case isolation policy"
+[Duration of case isolation]
+7
+
+[Duration of case isolation policy]
+364
+
+[Residual contacts after case isolation]
+0.25
+
+[Residual household contacts after case isolation]
+0.5
+
+[Number of change times for levels of case isolation]
+5
+
+//// Note: numbers here must match "Number of change times for levels of case isolation"; that any times listed here that are before "Case isolation start time" and after "Duration of case isolation policy" are irrelevant.
+[Change times for levels of case isolation]
+0 31 61 91 121
+
+[Residual contacts after case isolation over time]
+0.25 0.25 0.25 0.25 0.25
+
+[Residual household contacts after case isolation over time]
+0.5 0.5 0.5 0.5 0.5
+
+[Proportion of detected cases isolated over time]
+0.9 0.9 0.9 0.9 0.9
+
+[Case isolation trigger incidence per cell over time]
+0 0 0 0 0
+
+===================================		SOCIAL DISTANCING PARAMETERS
+
+[Social distancing start time]
+6
+
+[Delay to social distancing by admin unit]
+0	0	0
+
+[Duration of social distancing]
+364
+
+[Duration of social distancing by admin unit]
+364	364	364
+
+[Trigger incidence per cell for social distancing]
+0
+
+[Relative place contact rate given social distancing by place type]
+1 1 0.5 0.5
+
+[Relative household contact rate given social distancing]
+1.25
+
+[Relative spatial contact rate given social distancing]
+0.1
+
+[Minimum radius for social distancing]
+1
+
+[Proportion compliant with enhanced social distancing]
+0.0
+
+[Proportion compliant with enhanced social distancing by age group]
+0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0
+
+[Relative place contact rate given enhanced social distancing by place type]
+0.25	0.25	0.25	0.25
+
+[Relative household contact rate given enhanced social distancing]
+1
+
+[Relative spatial contact rate given enhanced social distancing]
+0.25
+
+[Delay for change in effectiveness of social distancing]
+1000
+
+[Relative place contact rate given social distancing by place type after change]
+1	1	0.75	0.75
+
+[Relative household contact rate given social distancing after change]
+1.25
+
+[Relative spatial contact rate given social distancing after change]
+0.25
+
+//// Must match "Change times for levels of social distancing"
+[Number of change times for levels of social distancing]
+6
+
+//// Note: numbers here must match "Number of change times for levels of social distancing"; that any times listed here that are before "Social distancing start time" and after "Duration of social distancing" are irrelevant.
+[Change times for levels of social distancing]
+0 31 61 91 121 151
+
+//// Again, want this to supercede "Relative place contact rate given social distancing by place type". Should be matrix of dimension "Number of change times for levels of social distancing" by Number of place types.
+[Relative place contact rates over time given social distancing by place type]
+1 1 0.5 0.5
+1 1 0.5 0.5
+1 1 0.5 0.5
+1 1 0.5 0.5
+1 1 0.5 0.5
+1 1 0.5 0.5
+
+////  Ideally want this to supercede "Relative household contact rate given social distancing", but need to preserved backwards compatibility for now.
+[Relative household contact rates over time given social distancing]
+1.25 1.25 1.25 1.25 1.25 1.25
+
+////  Ideally want this to supercede "Relative spatial contact rate given social distancing", but need to preserved backwards compatibility for now.
+[Relative spatial contact rates over time given social distancing]
+0.1 0.1 0.1 0.1 0.1 0.1
+
+[Relative household contact rates over time given enhanced social distancing]
+1 1 1 1 1 1
+
+[Relative spatial contact rates over time given enhanced social distancing]
+0.25 0.25 0.25 0.25 0.25 0.25
+
+[Relative place contact rates over time given enhanced social distancing by place type]
+0.25	0.25	0.25	0.25
+0.25	0.25	0.25	0.25
+0.25	0.25	0.25	0.25
+0.25	0.25	0.25	0.25
+0.25	0.25	0.25	0.25
+0.25	0.25	0.25	0.25
+
+[Trigger incidence per cell for social distancing over time]
+100 100 100 100 100 100
+    )CONFIG";
+}
+
+std::unique_ptr<ConfigFile> ParamsConfigBuilder::BuildConfig(const std::string &fname) {
+    return std::make_unique<ConfigFile>(fname, defaultContent);
+}

--- a/src/tests/ParamsConfigBuilder.h
+++ b/src/tests/ParamsConfigBuilder.h
@@ -1,0 +1,19 @@
+//
+// Created by lhumphreys on 10/05/2020.
+//
+
+#ifndef COVIDTEST_PARAMSCONFIGBUILDER_H
+#define COVIDTEST_PARAMSCONFIGBUILDER_H
+
+#include <memory>
+#include "ConfigFile.h"
+
+
+class ParamsConfigBuilder {
+public:
+    std::unique_ptr<ConfigFile> BuildConfig (const std::string& fname = "preParams.dat");
+
+};
+
+
+#endif //COVIDTEST_PARAMSCONFIGBUILDER_H

--- a/src/tests/PreParamConfigBuilder.cpp
+++ b/src/tests/PreParamConfigBuilder.cpp
@@ -57,9 +57,6 @@ namespace  {
 [Include administrative units within countries]
 1
 
-[Update timestep]
-0.25
-
 [Equilibriation time]
 0
 
@@ -472,5 +469,15 @@ Also comparable with 1957 pandemic attack rates from Chin.)
 }
 
 std::unique_ptr<ConfigFile> PreParamConfigBuilder::BuildConfig(const std::string &fname) {
-    return std::make_unique<ConfigFile>(fname, defaultContent);
+    std::stringstream buf;
+    buf << defaultContent << std::endl;
+    const auto addItem = [&] (const std::string& name, const std::optional<std::string>& val) {
+        if (val.has_value()) {
+            buf << std::endl;
+            buf << "[" << name << "]" << std::endl;
+            buf << val.value() << std::endl;
+        }
+    };
+    addItem("Update timestep", updateTimestep);
+    return std::make_unique<ConfigFile>(fname, buf.str());
 }

--- a/src/tests/PreParamConfigBuilder.cpp
+++ b/src/tests/PreParamConfigBuilder.cpp
@@ -12,16 +12,10 @@ namespace  {
 [Output bitmap]
 0
 
-[Output incidence by administrative unit]
-0
-
 [Output infection tree]
 0
 
 ==========================================================
-
-[Include administrative units within countries]
-1
 
 [Equilibriation time]
 0
@@ -442,6 +436,8 @@ std::unique_ptr<ConfigFile> PreParamConfigBuilder::BuildConfig(const std::string
     addItem("OutputNonSummaryResults", outputNonSummaryResults);
     addItem("Household attack rate", householdAttackRate);
     addItem("Household transmission denominator power", householdTransPowerDenom);
+    addItem("Include administrative units within countries", includeAdUnitsWithinCountries);
+    addItem("Output incidence by administrative unit", outputAdunitIncidence);
 
     return std::make_unique<ConfigFile>(fname, buf.str());
 }

--- a/src/tests/PreParamConfigBuilder.cpp
+++ b/src/tests/PreParamConfigBuilder.cpp
@@ -43,14 +43,6 @@ namespace  {
 0.6	0.7	0.75	1	1	1	1	1	1	1	1	1	1	1	1	0.75	0.5
 (POLYMOD, averaging 20-70)
 
-[Household attack rate]
-0.1
-(Adjusted to be the same as Cauchemez 2004 for R0=1.3.)
-
-[Household transmission denominator power]
-0.8
-(Cauchemez 2004)
-
 [Relative transmission rates for place types]
 0.14	0.14	0.1	0.07
 (School=2 x workplace. This gives Longini AJE 1988 age-specific infection attack rates for R0=1.3.
@@ -448,6 +440,9 @@ std::unique_ptr<ConfigFile> PreParamConfigBuilder::BuildConfig(const std::string
     addItem("OutputInfType", outputInfType);
     addItem("OutputNonSeverity", outputNonSeverity);
     addItem("OutputNonSummaryResults", outputNonSummaryResults);
+    addItem("Household attack rate", householdAttackRate);
+    addItem("Household transmission denominator power", householdTransPowerDenom);
 
     return std::make_unique<ConfigFile>(fname, buf.str());
 }
+

--- a/src/tests/PreParamConfigBuilder.cpp
+++ b/src/tests/PreParamConfigBuilder.cpp
@@ -12,45 +12,11 @@ namespace  {
 [Output bitmap]
 0
 
-[OutputAge]
-1
-
-[OutputSeverityAdminUnit]
-1
-
-[OutputR0]
-0
-
-[OutputControls]
-0
-
-[OutputCountry]
-0
-
-[OutputAdUnitVar]
-0
-
-[OutputHousehold]
-0
-
-[OutputInfType]
-0
-
-[OutputNonSeverity]
-0
-
-[OutputNonSummaryResults]
-0
-
 [Output incidence by administrative unit]
 0
 
 [Output infection tree]
 0
-
-[Only output non-extinct realisations]
-0
-
 
 ==========================================================
 
@@ -60,21 +26,12 @@ namespace  {
 [Equilibriation time]
 0
 
-[Sampling timestep]
-1
-
-[Sampling time]
-720
-
 [Grid size]
 0.075
 
 [Spatial domain for simulation]
 73	6.3
 136	54
-
-[Number of micro-cells per spatial cell width]
-9
 
 [Initial immunity profile by age]
 0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0
@@ -255,15 +212,6 @@ Also comparable with 1957 pandemic attack rates from Chin.)
 0
 
 ====================================
-
-[Number of realisations]
-1
-
-[Number of non-extinct realisations]
-1
-
-[Maximum number of cases defining small outbreak]
-10000
 
 [Do one generation]
 0
@@ -479,5 +427,27 @@ std::unique_ptr<ConfigFile> PreParamConfigBuilder::BuildConfig(const std::string
         }
     };
     addItem("Update timestep", updateTimestep);
+    addItem("Sampling timestep", samplingTimestep);
+    addItem("Sampling time", samplingTotalTime);
+
+    addItem("Number of realisations", numberOfRealisations);
+    addItem("Number of non-extinct realisations", numberOfNonExtinctRealisations);
+    addItem("Only output non-extinct realisations", onlyOutputNonExtinctRealisations);
+
+    addItem("Maximum number of cases defining small outbreak", maxNumForSmallOutbreak);
+
+    addItem("Number of micro-cells per spatial cell width", numMicroCellsPerSpatialCell);
+
+    addItem("OutputAge", outputAge);
+    addItem("OutputSeverityAdminUnit", outputSeverityAdminUnit);
+    addItem("OutputR0", outputR0);
+    addItem("OutputControls", outputControls);
+    addItem("OutputCountry", outputCountry);
+    addItem("OutputAdUnitVar", outputAdUnitVar);
+    addItem("OutputHousehold", outputHousehold);
+    addItem("OutputInfType", outputInfType);
+    addItem("OutputNonSeverity", outputNonSeverity);
+    addItem("OutputNonSummaryResults", outputNonSummaryResults);
+
     return std::make_unique<ConfigFile>(fname, buf.str());
 }

--- a/src/tests/PreParamConfigBuilder.cpp
+++ b/src/tests/PreParamConfigBuilder.cpp
@@ -1,0 +1,476 @@
+//
+// Created by lhumphreys on 10/05/2020.
+//
+
+#include "PreParamConfigBuilder.h"
+
+namespace  {
+    constexpr const char* const defaultContent = R"CONFIG(
+[Output every realisation]
+1
+
+[Output bitmap]
+0
+
+[OutputAge]
+1
+
+[OutputSeverityAdminUnit]
+1
+
+[OutputR0]
+0
+
+[OutputControls]
+0
+
+[OutputCountry]
+0
+
+[OutputAdUnitVar]
+0
+
+[OutputHousehold]
+0
+
+[OutputInfType]
+0
+
+[OutputNonSeverity]
+0
+
+[OutputNonSummaryResults]
+0
+
+[Output incidence by administrative unit]
+0
+
+[Output infection tree]
+0
+
+[Only output non-extinct realisations]
+0
+
+
+==========================================================
+
+[Include administrative units within countries]
+1
+
+[Update timestep]
+0.25
+
+[Equilibriation time]
+0
+
+[Sampling timestep]
+1
+
+[Sampling time]
+720
+
+[Grid size]
+0.075
+
+[Spatial domain for simulation]
+73	6.3
+136	54
+
+[Number of micro-cells per spatial cell width]
+9
+
+[Initial immunity profile by age]
+0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0
+
+[Initial immunity applied to all household members]
+1
+
+[Relative spatial contact rates by age]
+0.6	0.7	0.75	1	1	1	1	1	1	1	1	1	1	1	1	0.75	0.5
+(POLYMOD, averaging 20-70)
+
+[Household attack rate]
+0.1
+(Adjusted to be the same as Cauchemez 2004 for R0=1.3.)
+
+[Household transmission denominator power]
+0.8
+(Cauchemez 2004)
+
+[Relative transmission rates for place types]
+0.14	0.14	0.1	0.07
+(School=2 x workplace. This gives Longini AJE 1988 age-specific infection attack rates for R0=1.3.
+Also comparable with 1957 pandemic attack rates from Chin.)
+
+[Proportion of between group place links]
+0.25	0.25	0.25	0.25
+(25% of within-group contacts)
+
+[Include symptoms]
+1
+
+[Delay from end of latent period to start of symptoms]
+0.5
+(assume average time to symptom onset is a day)
+
+[Proportion symptomatic by age group]
+0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66 0.66
+
+[Symptomatic infectiousness relative to asymptomatic]
+1.5
+
+[Relative rate of random contacts if symptomatic]
+0.5
+
+[Relative level of place attendance if symptomatic]
+0.25 	0.25	0.5 	0.5
+
+[Model symptomatic withdrawal to home as true absenteeism]
+1
+
+[Maximum age of child at home for whom one adult also stays at home]
+16
+
+[Proportion of children at home for whom one adult also stays at home]
+1
+
+[Duration of place absenteeism for cases who withdraw]
+7
+
+[Place close round household]
+1
+
+[Absenteeism place closure]
+0
+
+#[Max absent time]
+#0
+#Not used because [Absenteeism Place Closure] is 0.
+
+[Initial number of infecteds]
+1000
+
+[Time when infection rate changes]
+30
+
+[Initial rate of importation of infections]
+0
+
+[Changed rate of importation of infections]
+0
+
+[Length of importation time profile provided]
+0
+
+[Daily importation time profile]
+0.00039637	0.000422404	0.000603232	0.000806818	0.000977838	0.001215654	0.001475435	0.001759331	0.002095855	0.002476933	0.002909161	0.003410198	0.003982451	0.004638805	0.005395127	0.00626298	0.007261369	0.008410463	0.009732184	0.011253768	0.01300553	0.015022328	0.017344927	0.020019826	0.023100555	0.026649391	0.030737285	0.035446471	0.04087166	0.04712199	0.054323081	0.062619805	0.072178958	0.083192875	0.095883242	0.110505088	0.127353055	0.146765647	0.169134051	0.194907414	0.224605405	0.258825037	0.298255169	0.343688393	0.396040694	0.456363956	0.525872339	0.605965353	0.698253328	0.804594637	0.927128729	1.068321589	1.231009953	1.418469229	1.634476217	1.883366252	2.170149943	2.500595049	2.881346836	3.320054954	3.825541988	4.407960394	5.07901906	5.852193458	6.742999237	7.769281222	8.951656384	10.31379847	11.88295306	13.690484	15.7725322	18.17054397	20.93225706	24.11247717	27.77414928	31.98955641	36.84153527	42.42484495	48.84810841	56.23529325	64.72777172	74.48650501	85.69401624	98.55689323	113.307934	130.2079818	149.5482524	171.650606	196.8670786	225.5805289	258.1996665	295.1479906	336.8602628	383.7567184	436.226154	494.5852818	559.0401758	629.6271715	706.1466306	788.0877032	874.5385994	964.1277368	1054.942274	1144.497997	1229.819016	1307.478109	1373.849859	1425.375658	1458.909049	1472.112189	1463.74025	1433.873478	1383.937547	1316.559006	1235.24025	1143.978092	1046.827852	947.5742692	849.4524822	755.0099762	666.1067926	583.9342875	509.1260534	441.8703774	382.0284161	329.2333209	282.9819783	242.6943429	207.7671547	177.6025491	151.6341438	129.3333359	110.223406	93.87499488	79.90856345	67.99027638	57.82900897	49.17215405	41.80131863	35.5286855	30.19272742	25.65482116	21.79680064	18.51741927	15.73036742	13.3620726	11.34984238	9.640307581	8.188006869	6.954337378	5.906435165	5.016354116	4.260368274	3.61826508	3.072912654	2.609742089	2.216371142	1.882286966	1.598554546	1.357591285	1.152944119	0.979149081	0.831549648	0.70620165	0.59974816	0.509342763	0.43256591	0.367362791	0.311990061	0.264964778	0.22502858	0.19111364	0.162311178	0.137852214	0.117080312	0.099440002	0.084459683	0.07173828	0.06093513	0.051761119
+
+[Reproduction number]
+2
+
+[Power of scaling of spatial R0 with density]
+0
+
+[Include latent period]
+1
+
+[Latent period]
+4.59
+(From Marc's estimates) - minus half a day to account for infectiousness pre symptom onset
+
+[Latent period inverse CDF]
+0	0.098616903	0.171170649	0.239705594	0.307516598	0.376194441	0.446827262	0.520343677	0.597665592	0.679808341	0.767974922	0.863671993	0.968878064	1.086313899	1.219915022	1.37573215	1.563841395	1.803041398	2.135346254	2.694118208	3.964172493
+(From Marc's estimates)
+
+[Model time varying infectiousness]
+1
+
+[Infectiousness profile]
+0.487464241	1	1.229764827	1.312453175	1.307955665	1.251658756	1.166040358	1.065716869	0.960199498	0.855580145	0.755628835	0.662534099	0.577412896	0.500665739	0.432225141	0.371729322	0.318643018	0.272340645	0.232162632	0.19745264	0.167581252	0.141960133	0.120049578	0.101361532	0.085459603	0.071957123	0.060514046	0.050833195	0.04265624	0.035759641	0.029950735	0.025064045	0.02095788	0.017511251	0.014621091	0.012199802	0.010173075	0.008477992	0.007061366	0.005878301	0.00489096	0.004067488	0.003381102	0.00280931	0.002333237	0.001937064	0.001607543	0.001333589	0.001105933	0.00091683	0.000759816	0.000629496	0.000521372	0.000431695	0.000357344	0.000295719	0.000244659
+
+[Infectious period]
+14
+
+[Infectious period inverse CDF]
+0	0.171566836	0.424943468	0.464725594	0.50866631	0.55773764	0.613298069	0.67732916	0.752886568	0.843151261	0.895791527	0.955973422	1.026225109	1.110607115	1.216272375	1.336349102	1.487791911	1.701882384	1.865779085	2.126940581	2.524164972
+(Cauchemez)
+
+[k of individual variation in infectiousness]
+1
+
+==========================================================
+
+[Use global triggers for interventions]
+1
+
+[Use admin unit triggers for interventions]
+0
+
+[Number of sampling intervals over which cumulative incidence measured for global trigger]
+1000
+
+[Use cases per thousand threshold for area controls]
+0
+
+[Divisor for per-capita global threshold (default 1000)]
+100000
+
+[Divisor for per-capita area threshold (default 1000)]
+1000
+
+[Trigger alert on deaths]
+1
+
+[Number of deaths accummulated before alert]
+10000
+
+[Number of days to accummulate cases/deaths before alert]
+100
+
+[Day of year trigger is reached]
+100
+
+[Alert trigger starts after interventions]
+1
+
+[Day of year interventions start]
+76
+
+[Proportion of cases detected for treatment]
+1
+
+[Treatment trigger incidence per cell]
+100000
+
+[Places close only once]
+0
+
+[Social distancing only once]
+1
+
+[Use ICU case triggers for interventions]
+1
+
+[Proportion of cases detected before outbreak alert]
+1
+
+[Number of detected cases needed before outbreak alert triggered]
+0
+
+====================================
+
+[Number of realisations]
+1
+
+[Number of non-extinct realisations]
+1
+
+[Maximum number of cases defining small outbreak]
+10000
+
+[Do one generation]
+0
+
+[Bitmap scale]
+60
+
+[Bitmap y:x aspect scaling]
+1.5
+
+[Calculate spatial correlations]
+0
+
+[Bitmap movie frame interval]
+300
+
+[Record infection events]
+0
+
+[Record infection events per run]
+0
+
+[Max number of infection events to record]
+10000000000
+
+[Limit number of infections]
+0
+
+[Max number of infections]
+10000000000
+
+===================================
+
+[Do Severity Analysis]
+1
+
+[Mean_MildToRecovery]
+7
+
+[Mean_ILIToRecovery]
+7
+
+[Mean_ILIToSARI]
+5
+
+[Mean_SARIToRecovery]
+1
+
+[Mean_SARIToDeath]
+1
+
+[Mean_SARIToCritical]
+1
+
+[Mean_CriticalToCritRecov]
+1
+
+[Mean_CriticalToDeath]
+1
+
+[Mean_CritRecovToRecov]
+1
+
+[MeanTimeToTest]
+4
+
+[MeanTimeToTestOffset]
+1
+
+[MeanTimeToTestCriticalOffset]
+3.3
+
+[MeanTimeToTestCritRecovOffset]
+9.32
+
+[MildToRecovery_icdf]
+0	0.341579599	0.436192391	0.509774887	0.574196702	0.633830053	0.690927761	0.74691114	0.802830695	0.859578883	0.918015187	0.97906363	1.043815683	1.113669859	1.190557274	1.277356871	1.378761429	1.50338422	1.670195767	1.938414132	2.511279379
+
+[ILIToRecovery_icdf]
+0	0.341579599	0.436192391	0.509774887	0.574196702	0.633830053	0.690927761	0.74691114	0.802830695	0.859578883	0.918015187	0.97906363	1.043815683	1.113669859	1.190557274	1.277356871	1.378761429	1.50338422	1.670195767	1.938414132	2.511279379
+
+[ILIToSARI_icdf]
+0	0.341579599	0.436192391	0.509774887	0.574196702	0.633830053	0.690927761	0.74691114	0.802830695	0.859578883	0.918015187	0.97906363	1.043815683	1.113669859	1.190557274	1.277356871	1.378761429	1.50338422	1.670195767	1.938414132	2.511279379
+
+[SARIToRecovery_icdf]
+0	0.634736097	1.217461548	1.805695261	2.41206761	3.044551205	3.71010552	4.415905623	5.170067405	5.982314035	6.864787504	7.833196704	8.908589322	10.12027655	11.51100029	13.14682956	15.13821107	17.69183155	21.27093904	27.35083955	41.35442157
+
+[SARIToDeath_icdf]
+0	1.703470233	2.39742257	2.970367222	3.491567676	3.988046604	4.474541783	4.960985883	5.455292802	5.964726999	6.496796075	7.06004732	7.665014091	8.325595834	9.061367792	9.901900127	10.8958347	12.133068	13.81280888	16.56124574	22.5803431
+
+[SARIToCritical_icdf]
+0	0.108407687	0.220267228	0.337653773	0.46159365	0.593106462	0.733343356	0.88367093	1.045760001	1.221701998	1.414175806	1.62669998	1.864032461	2.132837436	2.442868902	2.809242289	3.257272257	3.834402667	4.647120033	6.035113821	9.253953212
+
+[CriticalToCritRecov_icdf]
+0	1.308310071	1.87022015	2.338694632	2.76749788	3.177830401	3.581381361	3.986127838	4.398512135	4.824525291	5.270427517	5.743406075	6.252370864	6.809125902	7.430338867	8.141231404	8.983341913	10.03350866	11.46214198	13.80540164	18.95469153
+
+[CriticalToDeath_icdf]
+0	1.60649128	2.291051747	2.860938008	3.382077741	3.880425012	4.37026577	4.861330415	5.361460943	5.877935626	6.4183471	6.991401405	7.607881726	8.282065409	9.034104744	9.894486491	10.91341144	12.18372915	13.9113346	16.74394356	22.96541429
+
+[CritRecovToRecov_icdf]
+0	0.133993315	0.265922775	0.402188416	0.544657341	0.694774487	0.853984373	1.023901078	1.206436504	1.403942719	1.619402771	1.856711876	2.121118605	2.419957988	2.763950408	3.169692564	3.664959893	4.301777536	5.196849239	6.7222126	10.24997697
+
+[Prop_Mild_ByAge]
+0.666244874	0.666307235	0.666002907	0.665309462	0.663636419	0.660834577	0.657465236	0.65343285	0.650261465	0.64478501	0.633943755	0.625619329	0.609080537	0.600364976	0.5838608	0.566553872	0.564646465
+
+[Prop_ILI_ByAge]
+0.333122437	0.333153617	0.333001453	0.332654731	0.33181821	0.330417289	0.328732618	0.326716425	0.325130732	0.322392505	0.316971878	0.312809664	0.304540269	0.300182488	0.2919304	0.283276936	0.282323232
+
+[Prop_SARI_ByAge]
+0.000557744	0.000475283	0.000877703	0.001794658	0.004006955	0.007711884	0.012167229	0.017359248	0.021140307	0.027047193	0.03708932	0.039871236	0.040788928	0.027444452	0.101605674	0.142001415	0.150469697
+
+[Prop_Critical_ByAge]
+7.49444E-05	6.38641E-05	0.000117937	0.000241149	0.000538417	0.00103625	0.001634918	0.002491477	0.003467496	0.005775292	0.011995047	0.021699771	0.045590266	0.072008084	0.022603126	0.008167778	0.002560606
+
+[CFR_Critical_ByAge]
+0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896	0.5234896
+
+[CFR_SARI_ByAge]
+0.125893251	0.12261338	0.135672867	0.152667869	0.174303077	0.194187895	0.209361731	0.224432564	0.237013516	0.257828065	0.290874602	0.320763971	0.362563751	0.390965457	0.421151485	0.447545892	0.482
+
+[CFR_ILI_ByAge]
+0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0
+
+[Mean_ILIToDeath]
+7
+
+[ILIToDeath_icdf]
+0	2.257735908	3.171065856	3.924183798	4.608738224	5.260437017	5.898728066	6.53669783	7.184755068	7.852438367	8.549591424	9.287408763	10.07967529	10.94457146	11.90769274	13.00769447	14.3081531	15.92655201	18.12320384	21.71626849	29.58154704
+
+
+[Mean child age gap]
+2
+
+[Min adult age]
+19
+
+[Max MF partner age gap]
+5
+
+[Max FM partner age gap]
+5
+
+[Min parent age gap]
+19
+
+[Max parent age gap]
+44
+
+[Max child age]
+20
+
+[One Child Two Pers Prob]
+0.08
+
+[Two Child Three Pers Prob]
+0.11
+
+[One Pers House Prob Old]
+0.5
+
+[Two Pers House Prob Old]
+0.5
+
+[One Pers House Prob Young]
+0.23
+
+[Two Pers House Prob Young]
+0.23
+
+[One Child Prob Youngest Child Under Five]
+0.5
+
+[Two Children Prob Youngest Under Five]
+0.0
+
+[Prob Youngest Child Under Five]
+0
+
+[Zero Child Three Pers Prob]
+0.25
+
+[One Child Four Pers Prob]
+0.2
+
+[Young And Single Slope]
+0.7
+
+[Young And Single]
+36
+
+[No Child Pers Age]
+44
+
+[Old Pers Age]
+60
+
+[Three Child Five Pers Prob]
+0.5
+
+[Older Gen Gap]
+19
+)CONFIG";
+}
+
+std::unique_ptr<ConfigFile> PreParamConfigBuilder::BuildConfig(const std::string &fname) {
+    return std::make_unique<ConfigFile>(fname, defaultContent);
+}

--- a/src/tests/PreParamConfigBuilder.h
+++ b/src/tests/PreParamConfigBuilder.h
@@ -10,6 +10,8 @@
 #include "ConfigFile.h"
 
 struct PreParamConfigBuilder {
+    std::unique_ptr<ConfigFile> BuildConfig (const std::string& fname = "preParams.dat");
+
     std::optional<std::string> updateTimestep = "0.25";
     std::optional<std::string> samplingTimestep = "1";
     std::optional<std::string> samplingTotalTime = "720";
@@ -22,7 +24,6 @@ struct PreParamConfigBuilder {
 
     std::optional<std::string> numMicroCellsPerSpatialCell = "9";
 
-    std::unique_ptr<ConfigFile> BuildConfig (const std::string& fname = "preParams.dat");
 
     std::optional<std::string> outputAge;
     std::optional<std::string> outputSeverityAdminUnit;
@@ -34,6 +35,9 @@ struct PreParamConfigBuilder {
     std::optional<std::string> outputInfType;
     std::optional<std::string> outputNonSeverity;
     std::optional<std::string> outputNonSummaryResults;
+
+    std::optional<std::string> householdAttackRate = "0.1";
+    std::optional<std::string> householdTransPowerDenom = "0.8"; // see Cauchemez 2004. Deals with impact of increasing size of households on transmitablility
 };
 
 

--- a/src/tests/PreParamConfigBuilder.h
+++ b/src/tests/PreParamConfigBuilder.h
@@ -38,6 +38,9 @@ struct PreParamConfigBuilder {
 
     std::optional<std::string> householdAttackRate = "0.1";
     std::optional<std::string> householdTransPowerDenom = "0.8"; // see Cauchemez 2004. Deals with impact of increasing size of households on transmitablility
+
+    std::optional<std::string> includeAdUnitsWithinCountries = "1.0";
+    std::optional<std::string> outputAdunitIncidence = "0";
 };
 
 

--- a/src/tests/PreParamConfigBuilder.h
+++ b/src/tests/PreParamConfigBuilder.h
@@ -1,0 +1,17 @@
+//
+// Created by lhumphreys on 10/05/2020.
+//
+
+#ifndef COVIDTEST_PREPARAMCONFIGBUILDER_H
+#define COVIDTEST_PREPARAMCONFIGBUILDER_H
+
+#include <memory>
+#include "ConfigFile.h"
+
+class PreParamConfigBuilder {
+public:
+    std::unique_ptr<ConfigFile> BuildConfig (const std::string& fname = "preParams.dat");
+};
+
+
+#endif //COVIDTEST_PREPARAMCONFIGBUILDER_H

--- a/src/tests/PreParamConfigBuilder.h
+++ b/src/tests/PreParamConfigBuilder.h
@@ -11,8 +11,29 @@
 
 struct PreParamConfigBuilder {
     std::optional<std::string> updateTimestep = "0.25";
+    std::optional<std::string> samplingTimestep = "1";
+    std::optional<std::string> samplingTotalTime = "720";
+
+    std::optional<std::string> numberOfRealisations = "1";
+    std::optional<std::string> numberOfNonExtinctRealisations = "1";
+    std::optional<std::string> onlyOutputNonExtinctRealisations = "0";
+
+    std::optional<std::string> maxNumForSmallOutbreak = "10000";
+
+    std::optional<std::string> numMicroCellsPerSpatialCell = "9";
 
     std::unique_ptr<ConfigFile> BuildConfig (const std::string& fname = "preParams.dat");
+
+    std::optional<std::string> outputAge;
+    std::optional<std::string> outputSeverityAdminUnit;
+    std::optional<std::string> outputR0;
+    std::optional<std::string> outputControls;
+    std::optional<std::string> outputCountry;
+    std::optional<std::string> outputAdUnitVar;
+    std::optional<std::string> outputHousehold;
+    std::optional<std::string> outputInfType;
+    std::optional<std::string> outputNonSeverity;
+    std::optional<std::string> outputNonSummaryResults;
 };
 
 

--- a/src/tests/PreParamConfigBuilder.h
+++ b/src/tests/PreParamConfigBuilder.h
@@ -6,10 +6,12 @@
 #define COVIDTEST_PREPARAMCONFIGBUILDER_H
 
 #include <memory>
+#include <optional>
 #include "ConfigFile.h"
 
-class PreParamConfigBuilder {
-public:
+struct PreParamConfigBuilder {
+    std::optional<std::string> updateTimestep = "0.25";
+
     std::unique_ptr<ConfigFile> BuildConfig (const std::string& fname = "preParams.dat");
 };
 

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 #include "CovidSimTestFixture.h"
 #include "CovidSimCmdLineArgs.h"
-#include "Param.h"
 
 class ParamReadTest: public CovidSimTestFixture {
 protected:
@@ -9,11 +8,47 @@ protected:
 };
 
 class Airports: public ParamReadTest {};
+class CommandLineParams: public ParamReadTest {};
 class NetworkFiles: public ParamReadTest {};
 class OutFileBasePath: public ParamReadTest {};
 class ParamsFile: public ParamReadTest {};
 class PreParamsFile: public ParamReadTest {};
 class PlaceClose: public ParamReadTest {};
+
+TEST_F(CommandLineParams, AllProvided) {
+    args.cmdLineParam[0] = "1.0";
+    args.cmdLineParam[1] = "1.1";
+    args.cmdLineParam[2] = "1.2";
+    args.cmdLineParam[3] = "1.3";
+    args.cmdLineParam[4] = "1.4";
+    args.cmdLineParam[5] = "1.5";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_FLOAT_EQ(P().clP1, 1.0);
+    ASSERT_FLOAT_EQ(P().clP1, 1.0);
+    ASSERT_FLOAT_EQ(P().clP2, 1.1);
+    ASSERT_FLOAT_EQ(P().clP3, 1.2);
+    ASSERT_FLOAT_EQ(P().clP4, 1.3);
+    ASSERT_FLOAT_EQ(P().clP5, 1.4);
+    ASSERT_FLOAT_EQ(P().clP6, 1.5);
+}
+TEST_F(CommandLineParams, NoneProvided) {
+    args.cmdLineParam[0].reset();
+    args.cmdLineParam[1].reset();
+    args.cmdLineParam[2].reset();
+    args.cmdLineParam[3].reset();
+    args.cmdLineParam[4].reset();
+    args.cmdLineParam[5].reset();
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_FLOAT_EQ(P().clP1, 0.0);
+    ASSERT_FLOAT_EQ(P().clP1, 0.0);
+    ASSERT_FLOAT_EQ(P().clP2, 0.0);
+    ASSERT_FLOAT_EQ(P().clP3, 0.0);
+    ASSERT_FLOAT_EQ(P().clP4, 0.0);
+    ASSERT_FLOAT_EQ(P().clP5, 0.0);
+    ASSERT_FLOAT_EQ(P().clP6, 0.0);
+}
 
 TEST_F(OutFileBasePath, Specifed) {
     args.outFileBasePath = "results_";

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -9,6 +9,7 @@ protected:
 
 class Airports: public ParamReadTest {};
 class CommandLineParams: public ParamReadTest {};
+class DensityFileTests: public ParamReadTest {};
 class NetworkFiles: public ParamReadTest {};
 class OutFileBasePath: public ParamReadTest {};
 class ParamsFile: public ParamReadTest {};
@@ -48,6 +49,21 @@ TEST_F(CommandLineParams, NoneProvided) {
     ASSERT_FLOAT_EQ(P().clP4, 0.0);
     ASSERT_FLOAT_EQ(P().clP5, 0.0);
     ASSERT_FLOAT_EQ(P().clP6, 0.0);
+}
+
+TEST_F(DensityFileTests, OptionalField) {
+    args.densityFile.reset();
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().DoHeteroDensity, 0);
+}
+TEST_F(DensityFileTests, SpecifiedFile) {
+    args.densityFile = "density.dat";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().DoHeteroDensity, 1);
+    ASSERT_EQ(P().DoPeriodicBoundaries, 0);
+    ASSERT_STREQ(DensityFile, "density.dat");
 }
 
 TEST_F(OutFileBasePath, Specifed) {

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -8,10 +8,23 @@ protected:
     CovidSimCmdLineArgs args;
 };
 
+class Airports: public ParamReadTest {};
+class NetworkFiles: public ParamReadTest {};
+class OutFileBasePath: public ParamReadTest {};
 class ParamsFile: public ParamReadTest {};
 class PlaceClose: public ParamReadTest {};
-class NetworkFiles: public ParamReadTest {};
-class Airports: public ParamReadTest {};
+
+TEST_F(OutFileBasePath, Specifed) {
+    args.outFileBasePath = "results_";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_STREQ(OutFileBase(), "results_");
+}
+TEST_F(OutFileBasePath, MandatoryField) {
+    args.outFileBasePath.reset();
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_TRUE(Perr);
+}
 
 TEST_F(ParamsFile, ParamFileSet) {
     args.paramFile = "testParams.txt";

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -14,8 +14,9 @@ class DensityFiles: public ParamReadTest {};
 class NetworkFiles: public ParamReadTest {};
 class OutFileBasePath: public ParamReadTest {};
 class ParamsFile: public ParamReadTest {};
-class PreParamsFile: public ParamReadTest {};
 class PlaceClose: public ParamReadTest {};
+class PreParamsFile: public ParamReadTest {};
+class R0Scale: public ParamReadTest {};
 
 TEST_F(AdminFile, Specified) {
     args.adminFile = "adminFile.txt";
@@ -180,14 +181,24 @@ TEST_F(Airports, SpecifyAirportFile ) {
     ASSERT_EQ(GotAP, 1);
     ASSERT_STREQ(AirTravelFile, "airTravel.dat");
 }
+TEST_F(R0Scale, Optional) {
+    args.r0.reset();
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().R0scale, 1.0);
+}
+TEST_F(R0Scale, Specified) {
+    args.r0 = "2.3";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_FLOAT_EQ(P().R0scale, 2.3);
+}
 
 TEST_F(ParamReadTest, DefaultArgs) {
-    CovidSimCmdLineArgs args;
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
 }
 TEST_F(ParamReadTest, SetupSeeds) {
-    CovidSimCmdLineArgs args;
     args.setupSeeds[0] = "789";
     args.setupSeeds[1] = "456";
 
@@ -198,7 +209,6 @@ TEST_F(ParamReadTest, SetupSeeds) {
     ASSERT_EQ(P().setupSeed2, 456);
 }
 TEST_F(ParamReadTest, RunTimeSeeds) {
-    CovidSimCmdLineArgs args;
     args.runSeeds[0] = "123";
     args.runSeeds[1] = "456";
 

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -1,0 +1,9 @@
+//
+// Created by lhumphreys on 09/05/2020.
+//
+#include <gtest/gtest.h>
+
+TEST(Hello, World) {
+    ASSERT_TRUE(true);
+}
+

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -17,6 +17,20 @@ class ParamsFile: public ParamReadTest {};
 class PlaceClose: public ParamReadTest {};
 class PreParamsFile: public ParamReadTest {};
 class R0Scale: public ParamReadTest {};
+class MaxThreads: public ParamReadTest {};
+
+TEST_F(MaxThreads, Optional) {
+    args.maxThreads.reset();
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().MaxNumThreads, 0);
+}
+TEST_F(MaxThreads, Specified) {
+    args.maxThreads = "2";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().MaxNumThreads, 2);
+}
 
 TEST_F(AdminFile, Specified) {
     args.adminFile = "adminFile.txt";

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -7,6 +7,23 @@ class ParamReadTest: public CovidSimTestFixture {
 public:
 };
 
+class PlaceClose: public ParamReadTest {};
+class NetworkFile: public ParamReadTest {};
+
+TEST_F(PlaceClose, IndepThreashold_Default) {
+    CovidSimCmdLineArgs args;
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().PlaceCloseIndepThresh, 0L);
+}
+TEST_F(PlaceClose, IndepThreashold_Enabled) {
+    CovidSimCmdLineArgs args;
+    args.placeCloseIndepThreshold = "1";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().PlaceCloseIndepThresh, 1L);
+}
+
 TEST_F(ParamReadTest, DefaultArgs) {
     CovidSimCmdLineArgs args;
     InvokeReadParam(args.BuildCmdLine());

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -125,13 +125,13 @@ TEST_F(PreParamsFile, PreParamFileSet) {
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_STREQ(PreParamFile, "testPreParams.txt");
-    ASSERT_TRUE(GotPP);
 }
 TEST_F(PreParamsFile, OptionalField) {
+    args.paramFile = "params.txt";
     args.preParamFile.reset();
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
-    ASSERT_FALSE(GotPP);
+    ASSERT_STREQ(PreParamFile, "../Pre_params.txt");
 }
 
 TEST_F(ParamsFile, ParamFileSet) {

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -7,6 +7,7 @@ protected:
     CovidSimCmdLineArgs args;
 };
 
+class AdminFile: public ParamReadTest {};
 class Airports: public ParamReadTest {};
 class CommandLineParams: public ParamReadTest {};
 class DensityFiles: public ParamReadTest {};
@@ -15,6 +16,19 @@ class OutFileBasePath: public ParamReadTest {};
 class ParamsFile: public ParamReadTest {};
 class PreParamsFile: public ParamReadTest {};
 class PlaceClose: public ParamReadTest {};
+
+TEST_F(AdminFile, Specified) {
+    args.adminFile = "adminFile.txt";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_STREQ(AdunitFile(), "adminFile.txt");
+}
+TEST_F(AdminFile, Optional) {
+    args.adminFile.reset();
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(AdunitFile()[0], 0);
+}
 
 TEST_F(CommandLineParams, AllProvided) {
     args.cmdLineParam[0] = "1.0";

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -9,7 +9,7 @@ protected:
 
 class Airports: public ParamReadTest {};
 class CommandLineParams: public ParamReadTest {};
-class DensityFileTests: public ParamReadTest {};
+class DensityFiles: public ParamReadTest {};
 class NetworkFiles: public ParamReadTest {};
 class OutFileBasePath: public ParamReadTest {};
 class ParamsFile: public ParamReadTest {};
@@ -51,19 +51,32 @@ TEST_F(CommandLineParams, NoneProvided) {
     ASSERT_FLOAT_EQ(P().clP6, 0.0);
 }
 
-TEST_F(DensityFileTests, OptionalField) {
+TEST_F(DensityFiles, OptionalField) {
     args.densityFile.reset();
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().DoHeteroDensity, 0);
 }
-TEST_F(DensityFileTests, SpecifiedFile) {
+TEST_F(DensityFiles, SpecifiedFile) {
     args.densityFile = "density.dat";
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().DoHeteroDensity, 1);
     ASSERT_EQ(P().DoPeriodicBoundaries, 0);
     ASSERT_STREQ(DensityFile, "density.dat");
+}
+TEST_F(DensityFiles, OutputOptional) {
+    args.densityOutputFile.reset();
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().OutputDensFile, 0);
+}
+TEST_F(DensityFiles, OutputSpecified) {
+    args.densityOutputFile = "outputDensity.dat";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().OutputDensFile, 1);
+    ASSERT_STREQ(OutDensFile(), "outputDensity.dat");
 }
 
 TEST_F(OutFileBasePath, Specifed) {

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -10,6 +10,7 @@ protected:
 
 class PlaceClose: public ParamReadTest {};
 class NetworkFiles: public ParamReadTest {};
+class Airports: public ParamReadTest {};
 
 TEST_F(PlaceClose, IndepThreashold_Default) {
     InvokeReadParam(args.BuildCmdLine());
@@ -48,8 +49,18 @@ TEST_F(NetworkFiles, NotBothLoadAndSave) {
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_TRUE(Perr);
 }
-
-// TODO: Both Load and Save
+TEST_F(Airports, Default) {
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(GotAP, 0);
+}
+TEST_F(Airports, SpecifyAirportFile ) {
+    args.airTravelFile = "airTravel.dat";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(GotAP, 1);
+    ASSERT_STREQ(AirTravelFile, "airTravel.dat");
+}
 
 TEST_F(ParamReadTest, DefaultArgs) {
     CovidSimCmdLineArgs args;

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -12,6 +12,7 @@ class Airports: public ParamReadTest {};
 class NetworkFiles: public ParamReadTest {};
 class OutFileBasePath: public ParamReadTest {};
 class ParamsFile: public ParamReadTest {};
+class PreParamsFile: public ParamReadTest {};
 class PlaceClose: public ParamReadTest {};
 
 TEST_F(OutFileBasePath, Specifed) {
@@ -24,6 +25,20 @@ TEST_F(OutFileBasePath, MandatoryField) {
     args.outFileBasePath.reset();
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_TRUE(Perr);
+}
+
+TEST_F(PreParamsFile, PreParamFileSet) {
+    args.preParamFile = "testPreParams.txt";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_STREQ(PreParamFile, "testPreParams.txt");
+    ASSERT_TRUE(GotPP);
+}
+TEST_F(PreParamsFile, OptionalField) {
+    args.preParamFile.reset();
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_FALSE(GotPP);
 }
 
 TEST_F(ParamsFile, ParamFileSet) {

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -1,9 +1,36 @@
-//
-// Created by lhumphreys on 09/05/2020.
-//
 #include <gtest/gtest.h>
+#include "CovidSimTestFixture.h"
+#include "CovidSimCmdLineArgs.h"
+#include "Param.h"
 
-TEST(Hello, World) {
-    ASSERT_TRUE(true);
+class ParamReadTest: public CovidSimTestFixture {
+public:
+};
+
+TEST_F(ParamReadTest, DefaultArgs) {
+    CovidSimCmdLineArgs args;
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
 }
+TEST_F(ParamReadTest, SetupSeeds) {
+    CovidSimCmdLineArgs args;
+    args.setupSeeds[0] = "789";
+    args.setupSeeds[1] = "456";
 
+    InvokeReadParam(args.BuildCmdLine());
+
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().setupSeed1, 789);
+    ASSERT_EQ(P().setupSeed2, 456);
+}
+TEST_F(ParamReadTest, RunTimeSeeds) {
+    CovidSimCmdLineArgs args;
+    args.runSeeds[0] = "123";
+    args.runSeeds[1] = "456";
+
+    InvokeReadParam(args.BuildCmdLine());
+
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().runSeed1, 123);
+    ASSERT_EQ(P().runSeed2, 456);
+}

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -8,9 +8,22 @@ protected:
     CovidSimCmdLineArgs args;
 };
 
+class ParamsFile: public ParamReadTest {};
 class PlaceClose: public ParamReadTest {};
 class NetworkFiles: public ParamReadTest {};
 class Airports: public ParamReadTest {};
+
+TEST_F(ParamsFile, ParamFileSet) {
+    args.paramFile = "testParams.txt";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_STREQ(ParamFile, "testParams.txt");
+}
+TEST_F(ParamsFile, MandatoryField) {
+    args.paramFile.reset();
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_TRUE(Perr);
+}
 
 TEST_F(PlaceClose, IndepThreashold_Default) {
     InvokeReadParam(args.BuildCmdLine());

--- a/src/tests/paramReadTests.cpp
+++ b/src/tests/paramReadTests.cpp
@@ -4,25 +4,52 @@
 #include "Param.h"
 
 class ParamReadTest: public CovidSimTestFixture {
-public:
+protected:
+    CovidSimCmdLineArgs args;
 };
 
 class PlaceClose: public ParamReadTest {};
-class NetworkFile: public ParamReadTest {};
+class NetworkFiles: public ParamReadTest {};
 
 TEST_F(PlaceClose, IndepThreashold_Default) {
-    CovidSimCmdLineArgs args;
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().PlaceCloseIndepThresh, 0L);
 }
 TEST_F(PlaceClose, IndepThreashold_Enabled) {
-    CovidSimCmdLineArgs args;
     args.placeCloseIndepThreshold = "1";
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().PlaceCloseIndepThresh, 1L);
 }
+
+TEST_F(NetworkFiles, Default) {
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().LoadSaveNetwork, 0);
+}
+TEST_F(NetworkFiles, LoadFile) {
+    args.networkFileToLoad = "fileToLoad";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().LoadSaveNetwork, 1);
+    ASSERT_STREQ(NetworkFile, "fileToLoad");
+}
+TEST_F(NetworkFiles, SaveFile) {
+    args.networkFileToLoad = "fileToSave";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().LoadSaveNetwork, 1);
+    ASSERT_STREQ(NetworkFile, "fileToSave");
+}
+TEST_F(NetworkFiles, NotBothLoadAndSave) {
+    args.networkFileToSave = "fileToSave";
+    args.networkFileToLoad = "fileToLoad";
+    InvokeReadParam(args.BuildCmdLine());
+    ASSERT_TRUE(Perr);
+}
+
+// TODO: Both Load and Save
 
 TEST_F(ParamReadTest, DefaultArgs) {
     CovidSimCmdLineArgs args;
@@ -51,3 +78,4 @@ TEST_F(ParamReadTest, RunTimeSeeds) {
     ASSERT_EQ(P().runSeed1, 123);
     ASSERT_EQ(P().runSeed2, 456);
 }
+// TODO: Currently the commandline handler has no handling for bas seed arguments

--- a/src/tests/testCommandLineParsing.cpp
+++ b/src/tests/testCommandLineParsing.cpp
@@ -21,26 +21,26 @@ class MaxThreads: public CommandLineParsingTest {};
 
 TEST_F(MaxThreads, Optional) {
     args.maxThreads.reset();
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().MaxNumThreads, 0);
 }
 TEST_F(MaxThreads, Specified) {
     args.maxThreads = "2";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().MaxNumThreads, 2);
 }
 
 TEST_F(AdminFile, Specified) {
     args.adminFile = "adminFile.txt";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_STREQ(AdunitFile(), "adminFile.txt");
 }
 TEST_F(AdminFile, Optional) {
     args.adminFile.reset();
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(AdunitFile()[0], 0);
 }
@@ -52,7 +52,7 @@ TEST_F(CommandLineParams, AllProvided) {
     args.cmdLineParam[3] = "1.3";
     args.cmdLineParam[4] = "1.4";
     args.cmdLineParam[5] = "1.5";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_FLOAT_EQ(P().clP1, 1.0);
     ASSERT_FLOAT_EQ(P().clP1, 1.0);
@@ -69,7 +69,7 @@ TEST_F(CommandLineParams, NoneProvided) {
     args.cmdLineParam[3].reset();
     args.cmdLineParam[4].reset();
     args.cmdLineParam[5].reset();
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_FLOAT_EQ(P().clP1, 0.0);
     ASSERT_FLOAT_EQ(P().clP1, 0.0);
@@ -82,13 +82,13 @@ TEST_F(CommandLineParams, NoneProvided) {
 
 TEST_F(DensityFiles, OptionalField) {
     args.densityFile.reset();
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().DoHeteroDensity, 0);
 }
 TEST_F(DensityFiles, SpecifiedFile) {
     args.densityFile = "density.dat";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().DoHeteroDensity, 1);
     ASSERT_EQ(P().DoPeriodicBoundaries, 0);
@@ -96,13 +96,13 @@ TEST_F(DensityFiles, SpecifiedFile) {
 }
 TEST_F(DensityFiles, OutputOptional) {
     args.densityOutputFile.reset();
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().OutputDensFile, 0);
 }
 TEST_F(DensityFiles, OutputSpecified) {
     args.densityOutputFile = "outputDensity.dat";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().OutputDensFile, 1);
     ASSERT_STREQ(OutDensFile(), "outputDensity.dat");
@@ -110,70 +110,70 @@ TEST_F(DensityFiles, OutputSpecified) {
 
 TEST_F(OutFileBasePath, Specifed) {
     args.outFileBasePath = "results_";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_STREQ(OutFileBase(), "results_");
     ASSERT_STREQ(OutFile(), "results_");
 }
 TEST_F(OutFileBasePath, MandatoryField) {
     args.outFileBasePath.reset();
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_TRUE(Perr);
 }
 
 TEST_F(PreParamsFile, PreParamFileSet) {
     args.preParamFile = "testPreParams.txt";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_STREQ(PreParamFile, "testPreParams.txt");
 }
 TEST_F(PreParamsFile, OptionalField) {
     args.paramFile = "params.txt";
     args.preParamFile.reset();
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_STREQ(PreParamFile, "../Pre_params.txt");
 }
 
 TEST_F(ParamsFile, ParamFileSet) {
     args.paramFile = "testParams.txt";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_STREQ(ParamFile, "testParams.txt");
 }
 TEST_F(ParamsFile, MandatoryField) {
     args.paramFile.reset();
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_TRUE(Perr);
 }
 
 TEST_F(PlaceClose, IndepThreashold_Default) {
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().PlaceCloseIndepThresh, 0L);
 }
 TEST_F(PlaceClose, IndepThreashold_Enabled) {
     args.placeCloseIndepThreshold = "1";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().PlaceCloseIndepThresh, 1L);
 }
 
 TEST_F(NetworkFiles, Default) {
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().LoadSaveNetwork, 0);
 }
 TEST_F(NetworkFiles, LoadFile) {
     args.networkFileToLoad = "fileToLoad";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().LoadSaveNetwork, 1);
     ASSERT_STREQ(NetworkFile, "fileToLoad");
 }
 TEST_F(NetworkFiles, SaveFile) {
     args.networkFileToLoad = "fileToSave";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().LoadSaveNetwork, 1);
     ASSERT_STREQ(NetworkFile, "fileToSave");
@@ -181,43 +181,43 @@ TEST_F(NetworkFiles, SaveFile) {
 TEST_F(NetworkFiles, NotBothLoadAndSave) {
     args.networkFileToSave = "fileToSave";
     args.networkFileToLoad = "fileToLoad";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_TRUE(Perr);
 }
 TEST_F(Airports, Default) {
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(GotAP, 0);
 }
 TEST_F(Airports, SpecifyAirportFile ) {
     args.airTravelFile = "airTravel.dat";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(GotAP, 1);
     ASSERT_STREQ(AirTravelFile, "airTravel.dat");
 }
 TEST_F(R0Scale, Optional) {
     args.r0.reset();
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().R0scale, 1.0);
 }
 TEST_F(R0Scale, Specified) {
     args.r0 = "2.3";
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_FLOAT_EQ(P().R0scale, 2.3);
 }
 
 TEST_F(CommandLineParsingTest, DefaultArgs) {
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
 }
 TEST_F(CommandLineParsingTest, SetupSeeds) {
     args.setupSeeds[0] = "789";
     args.setupSeeds[1] = "456";
 
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
 
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().setupSeed1, 789);
@@ -227,7 +227,7 @@ TEST_F(CommandLineParsingTest, RunTimeSeeds) {
     args.runSeeds[0] = "123";
     args.runSeeds[1] = "456";
 
-    InvokeReadParam(args.BuildCmdLine());
+    InvokeParseCmdLine(args.BuildCmdLine());
 
     ASSERT_FALSE(Perr);
     ASSERT_EQ(P().runSeed1, 123);

--- a/src/tests/testCommandLineParsing.cpp
+++ b/src/tests/testCommandLineParsing.cpp
@@ -113,6 +113,7 @@ TEST_F(OutFileBasePath, Specifed) {
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
     ASSERT_STREQ(OutFileBase(), "results_");
+    ASSERT_STREQ(OutFile(), "results_");
 }
 TEST_F(OutFileBasePath, MandatoryField) {
     args.outFileBasePath.reset();

--- a/src/tests/testCommandLineParsing.cpp
+++ b/src/tests/testCommandLineParsing.cpp
@@ -7,18 +7,37 @@ protected:
     CovidSimCmdLineArgs args;
 };
 
-class AdminFile: public CommandLineParsingTest {};
-class Airports: public CommandLineParsingTest {};
-class CommandLineParams: public CommandLineParsingTest {};
-class DensityFiles: public CommandLineParsingTest {};
-class NetworkFiles: public CommandLineParsingTest {};
-class OutFileBasePath: public CommandLineParsingTest {};
-class ParamsFile: public CommandLineParsingTest {};
-class PlaceClose: public CommandLineParsingTest {};
-class PreParamsFile: public CommandLineParsingTest {};
-class R0Scale: public CommandLineParsingTest {};
-class MaxThreads: public CommandLineParsingTest {};
+namespace {
+    class AdminFile: public CommandLineParsingTest {};
+    class Airports: public CommandLineParsingTest {};
+    class CommandLineParams: public CommandLineParsingTest {};
+    class DensityFiles: public CommandLineParsingTest {};
+    class Kernel: public CommandLineParsingTest {};
+    class MaxThreads: public CommandLineParsingTest {};
+    class NetworkFiles: public CommandLineParsingTest {};
+    class OutFileBasePath: public CommandLineParsingTest {};
+    class ParamsFile: public CommandLineParsingTest {};
+    class PlaceClose: public CommandLineParsingTest {};
+    class PreParamsFile: public CommandLineParsingTest {};
+    class R0Scale: public CommandLineParsingTest {};
+}
 
+TEST_F(Kernel, Optional) {
+    args.kernelOffsetScale.reset();
+    args.kernelPowerScale.reset();
+    InvokeParseCmdLine(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().KernelOffsetScale, 1);
+    ASSERT_EQ(P().KernelPowerScale, 1);
+}
+TEST_F(Kernel, Specified) {
+    args.kernelOffsetScale = "1.5";
+    args.kernelPowerScale = "2.5";
+    InvokeParseCmdLine(args.BuildCmdLine());
+    ASSERT_FALSE(Perr);
+    ASSERT_EQ(P().KernelOffsetScale, 1.5);
+    ASSERT_EQ(P().KernelPowerScale, 2.5);
+}
 TEST_F(MaxThreads, Optional) {
     args.maxThreads.reset();
     InvokeParseCmdLine(args.BuildCmdLine());

--- a/src/tests/testCommandLineParsing.cpp
+++ b/src/tests/testCommandLineParsing.cpp
@@ -2,22 +2,22 @@
 #include "CovidSimTestFixture.h"
 #include "CovidSimCmdLineArgs.h"
 
-class ParamReadTest: public CovidSimTestFixture {
+class CommandLineParsingTest: public CovidSimTestFixture {
 protected:
     CovidSimCmdLineArgs args;
 };
 
-class AdminFile: public ParamReadTest {};
-class Airports: public ParamReadTest {};
-class CommandLineParams: public ParamReadTest {};
-class DensityFiles: public ParamReadTest {};
-class NetworkFiles: public ParamReadTest {};
-class OutFileBasePath: public ParamReadTest {};
-class ParamsFile: public ParamReadTest {};
-class PlaceClose: public ParamReadTest {};
-class PreParamsFile: public ParamReadTest {};
-class R0Scale: public ParamReadTest {};
-class MaxThreads: public ParamReadTest {};
+class AdminFile: public CommandLineParsingTest {};
+class Airports: public CommandLineParsingTest {};
+class CommandLineParams: public CommandLineParsingTest {};
+class DensityFiles: public CommandLineParsingTest {};
+class NetworkFiles: public CommandLineParsingTest {};
+class OutFileBasePath: public CommandLineParsingTest {};
+class ParamsFile: public CommandLineParsingTest {};
+class PlaceClose: public CommandLineParsingTest {};
+class PreParamsFile: public CommandLineParsingTest {};
+class R0Scale: public CommandLineParsingTest {};
+class MaxThreads: public CommandLineParsingTest {};
 
 TEST_F(MaxThreads, Optional) {
     args.maxThreads.reset();
@@ -208,11 +208,11 @@ TEST_F(R0Scale, Specified) {
     ASSERT_FLOAT_EQ(P().R0scale, 2.3);
 }
 
-TEST_F(ParamReadTest, DefaultArgs) {
+TEST_F(CommandLineParsingTest, DefaultArgs) {
     InvokeReadParam(args.BuildCmdLine());
     ASSERT_FALSE(Perr);
 }
-TEST_F(ParamReadTest, SetupSeeds) {
+TEST_F(CommandLineParsingTest, SetupSeeds) {
     args.setupSeeds[0] = "789";
     args.setupSeeds[1] = "456";
 
@@ -222,7 +222,7 @@ TEST_F(ParamReadTest, SetupSeeds) {
     ASSERT_EQ(P().setupSeed1, 789);
     ASSERT_EQ(P().setupSeed2, 456);
 }
-TEST_F(ParamReadTest, RunTimeSeeds) {
+TEST_F(CommandLineParsingTest, RunTimeSeeds) {
     args.runSeeds[0] = "123";
     args.runSeeds[1] = "456";
 
@@ -232,4 +232,3 @@ TEST_F(ParamReadTest, RunTimeSeeds) {
     ASSERT_EQ(P().runSeed1, 123);
     ASSERT_EQ(P().runSeed2, 456);
 }
-// TODO: Currently the commandline handler has no handling for bas seed arguments

--- a/src/tests/testError.cpp
+++ b/src/tests/testError.cpp
@@ -12,7 +12,7 @@
 #include <cstdarg>
 #include <sstream>
 
-class CriticalError: std::exception {
+class CriticalError: public std::exception {
 public:
     CriticalError(std::string msg): msg(std::move(msg)) {}
     const char* what() const noexcept  override { return msg.c_str();}

--- a/src/tests/testError.cpp
+++ b/src/tests/testError.cpp
@@ -1,0 +1,38 @@
+/**
+ * When the model hits an unrecoverable error (such as invalid input params)
+ * it reports the error and then immediately exist the application.
+ *
+ * Whilst this is correct behaviour when running the model for real - this
+ * stop us from creating unit tests that check this validation.
+ *
+ * To work around this in we replace the error.cpp implementation with our own
+ * at link time.
+ */
+#include <Error.h>
+#include <cstdarg>
+#include <sstream>
+
+class CriticalError: std::exception {
+public:
+    CriticalError(std::string msg): msg(std::move(msg)) {}
+    const char* what() const noexcept  override { return msg.c_str();}
+private:
+    std::string msg;
+};
+
+void ErrorCritical(const char* fmt, const char* file, int line, ...)
+{
+    va_list args;
+    va_start(args, line);
+
+    constexpr size_t maxErrLen = 1024*2;
+    char errMsgBuf[maxErrLen] = "";
+    std::vsnprintf(errMsgBuf, maxErrLen, fmt, args);
+
+    va_end(args);
+
+    std::stringstream buf;
+    buf << "[" << file << " " << line << "] " << errMsgBuf << std::endl;
+
+    throw CriticalError(buf.str());
+}

--- a/src/tests/testParamParsing.cpp
+++ b/src/tests/testParamParsing.cpp
@@ -46,8 +46,40 @@ namespace {
     class Households: public ParamParsingTest {};
     class Output: public ParamParsingTest {};
     class Kernel: public ParamParsingTest {};
+    class AdUnits: public ParamParsingTest {};
 }
 
+TEST_F(AdUnits, Specified) {
+    preParams.includeAdUnitsWithinCountries = "1";
+    adUnit.divisorForCountries = "1000";
+    preParams.outputAdunitIncidence = "1";
+    SetupAndParseParams();
+    ASSERT_EQ(P().DoAdUnits, 1);
+    ASSERT_EQ(P().CountryDivisor, 1000);
+    ASSERT_EQ(P().DoAdunitOutput, 1);
+}
+TEST_F(AdUnits, Disabled) {
+    preParams.includeAdUnitsWithinCountries = "0";
+    SetupAndParseParams();
+    ASSERT_EQ(P().DoAdUnits, 0);
+    ASSERT_EQ(P().DoAdunitBoundaries, 0);
+    ASSERT_EQ(P().DoAdunitBoundaryOutput, 0);
+    ASSERT_EQ(P().DoAdunitOutput, 0);
+    ASSERT_EQ(P().DoCorrectAdunitPop, 0);
+    ASSERT_EQ(P().DoSpecifyPop, 0);
+    ASSERT_EQ(P().AdunitLevel1Divisor, 1);
+    ASSERT_EQ(P().AdunitLevel1Mask, 1000000000);
+    ASSERT_EQ(P().AdunitBitmapDivisor, 1);
+}
+TEST_F(AdUnits, DefaultEnabled) {
+    preParams.includeAdUnitsWithinCountries.reset();
+    adUnit.divisorForCountries.reset();
+    preParams.outputAdunitIncidence.reset();
+    SetupAndParseParams();
+    ASSERT_EQ(P().DoAdUnits, 1);
+    ASSERT_EQ(P().CountryDivisor, 1);
+    ASSERT_EQ(P().DoAdunitOutput, 0);
+}
 TEST_F(Kernel, Specified) {
     adUnit.kernelResolution = "2000000";
     adUnit.kernelHigherResolutionFactor  = "40";

--- a/src/tests/testParamParsing.cpp
+++ b/src/tests/testParamParsing.cpp
@@ -31,6 +31,18 @@ protected:
     }
 };
 
+class TimeStep: public ParamParsingTest{};
+
+TEST_F(TimeStep, ReadSteps) {
+    preParams.updateTimestep = "0.25";
+    SetupAndParseParams();
+    ASSERT_EQ(P().TimeStep, 0.25);
+}
+TEST_F(TimeStep, MandatoryUpdateTimestep) {
+    preParams.updateTimestep.reset();
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*Update timestep");
+}
+
 TEST_F(ParamParsingTest, DefaultValues) {
     SetupAndParseParams();
 }

--- a/src/tests/testParamParsing.cpp
+++ b/src/tests/testParamParsing.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+#include "CovidSimTestFixture.h"
+#include "CovidSimCmdLineArgs.h"
+#include "PreParamConfigBuilder.h"
+#include "AdunitConfigBuilder.h"
+#include "ParamsConfigBuilder.h"
+
+class ParamParsingTest: public CovidSimTestFixture {
+protected:
+    CovidSimCmdLineArgs args;
+    PreParamConfigBuilder preParams;
+    ParamsConfigBuilder params;
+    AdunitConfigBuilder adUnit;
+
+    void SetUp() override {
+        CovidSimTestFixture::SetUp();
+        args.paramFile = "params.txt";
+        args.preParamFile = "preParams.txt";
+        args.adminFile = "admin.txt";
+        args.r0 = "1.5";
+    }
+
+    void SetupAndParseParams() {
+        InvokeParseCmdLine(args.BuildCmdLine());
+        InvokeSetupThreads();
+        auto paramFile = params.BuildConfig(ParamFile);
+        auto preParamFile = preParams.BuildConfig(PreParamFile);
+        auto adUnitFile = adUnit.BuildCfgFile(AdunitFile());
+
+        InvokeReadParams();
+    }
+};
+
+TEST_F(ParamParsingTest, DefaultValues) {
+    SetupAndParseParams();
+}
+
+
+
+
+
+
+
+
+
+
+

--- a/src/tests/testParamParsing.cpp
+++ b/src/tests/testParamParsing.cpp
@@ -44,6 +44,191 @@ namespace {
     class Cells: public ParamParsingTest {};
     class Households: public ParamParsingTest {};
     class Output: public ParamParsingTest {};
+    class Kernel: public ParamParsingTest {};
+}
+
+TEST_F(Kernel, Specified) {
+    adUnit.kernelResolution = "2000000";
+    adUnit.kernelHigherResolutionFactor  = "40";
+    adUnit.kernelType = "2";
+    adUnit.kernelScale = "4000";
+    adUnit.kernelParam3 = "3";
+    adUnit.kernelParam4 = "4";
+    adUnit.kernelShape = "3";
+    adUnit.kernelScaleParamForPlaces = "3000 3500 4000 4500";
+    adUnit.kernelShapeParamForPlaces = "2 3 4 5";
+    adUnit.kernelParam3ForPlaces = "1 2 3 4";
+    adUnit.kernelParam4ForPlaces = "5 6 7 8";
+    SetupAndParseParams();
+    ASSERT_EQ(P().NKR, 2e6);
+    ASSERT_EQ(P().NK_HR, 40);
+    ASSERT_EQ(P().MoveKernelType, 2);
+    ASSERT_EQ(P().MoveKernelShape, 3);
+    ASSERT_EQ(P().MoveKernelScale, 4000);
+    ASSERT_EQ(P().MoveKernelP3, 3);
+    ASSERT_EQ(P().MoveKernelP4, 4);
+
+    ASSERT_EQ(P().PlaceTypeKernelScale[0], 3000);
+    ASSERT_EQ(P().PlaceTypeKernelScale[1], 3500);
+    ASSERT_EQ(P().PlaceTypeKernelScale[2], 4000);
+    ASSERT_EQ(P().PlaceTypeKernelScale[3], 4500);
+
+    ASSERT_EQ(P().PlaceTypeKernelShape[0], 2);
+    ASSERT_EQ(P().PlaceTypeKernelShape[1], 3);
+    ASSERT_EQ(P().PlaceTypeKernelShape[2], 4);
+    ASSERT_EQ(P().PlaceTypeKernelShape[3], 5);
+
+    ASSERT_EQ(P().PlaceTypeKernelP3[0], 1);
+    ASSERT_EQ(P().PlaceTypeKernelP3[1], 2);
+    ASSERT_EQ(P().PlaceTypeKernelP3[2], 3);
+    ASSERT_EQ(P().PlaceTypeKernelP3[3], 4);
+
+    ASSERT_EQ(P().PlaceTypeKernelP4[0], 5);
+    ASSERT_EQ(P().PlaceTypeKernelP4[1], 6);
+    ASSERT_EQ(P().PlaceTypeKernelP4[2], 7);
+    ASSERT_EQ(P().PlaceTypeKernelP4[3], 8);
+}
+TEST_F(Kernel, CmdLineScales) {
+    args.kernelOffsetScale = "1.5";
+    args.kernelPowerScale = "2.5";
+
+    adUnit.kernelResolution = "2000000";
+    adUnit.kernelHigherResolutionFactor  = "40";
+    adUnit.kernelType = "3";
+    adUnit.kernelScale = "4000";
+    adUnit.kernelShape = "3";
+    adUnit.kernelParam3 = "3";
+    adUnit.kernelParam4 = "4";
+    adUnit.kernelScaleParamForPlaces.reset();
+    adUnit.kernelShapeParamForPlaces.reset();
+    adUnit.kernelParam3ForPlaces.reset();
+    adUnit.kernelParam4ForPlaces.reset();
+    SetupAndParseParams();
+    ASSERT_EQ(P().NKR, 2e6);
+    ASSERT_EQ(P().NK_HR, 40);
+    ASSERT_EQ(P().MoveKernelType, 3);
+    ASSERT_EQ(P().MoveKernelScale, 4000 * 1.5);
+    ASSERT_EQ(P().MoveKernelP3, 3);
+    ASSERT_EQ(P().MoveKernelP4, 4);
+    ASSERT_EQ(P().MoveKernelShape, 3 * 2.5);
+
+    ASSERT_EQ(P().PlaceTypeKernelScale[0], 4000 *1.5);
+    ASSERT_EQ(P().PlaceTypeKernelScale[1], 4000 *1.5);
+    ASSERT_EQ(P().PlaceTypeKernelScale[2], 4000 *1.5);
+    ASSERT_EQ(P().PlaceTypeKernelScale[3], 4000 *1.5);
+
+    ASSERT_EQ(P().PlaceTypeKernelShape[0], 3 * 2.5);
+    ASSERT_EQ(P().PlaceTypeKernelShape[1], 3 * 2.5);
+    ASSERT_EQ(P().PlaceTypeKernelShape[2], 3 * 2.5);
+    ASSERT_EQ(P().PlaceTypeKernelShape[3], 3 * 2.5);
+}
+TEST_F(Kernel, CmdLineScalesNoScaleExplicitPlaceConfig) {
+    args.kernelOffsetScale = "1.5";
+    args.kernelPowerScale = "2.5";
+
+    adUnit.kernelResolution = "2000000";
+    adUnit.kernelHigherResolutionFactor  = "40";
+    adUnit.kernelType = "3";
+    adUnit.kernelScale = "4000";
+    adUnit.kernelShape = "3";
+    adUnit.kernelParam3 = "3";
+    adUnit.kernelParam4 = "4";
+    adUnit.kernelScaleParamForPlaces = "4000 4000 4000 4000";
+    adUnit.kernelShapeParamForPlaces = "3 3 3 3";
+    adUnit.kernelTypeForPlaces = "1 2 3 4";
+    SetupAndParseParams();
+    ASSERT_EQ(P().NKR, 2e6);
+    ASSERT_EQ(P().NK_HR, 40);
+    ASSERT_EQ(P().MoveKernelType, 3);
+    ASSERT_EQ(P().MoveKernelScale, 4000 * 1.5);
+    ASSERT_EQ(P().MoveKernelP3, 3);
+    ASSERT_EQ(P().MoveKernelP4, 4);
+    ASSERT_EQ(P().MoveKernelShape, 3 * 2.5);
+
+    ASSERT_EQ(P().PlaceTypeKernelScale[0], 4000);
+    ASSERT_EQ(P().PlaceTypeKernelScale[1], 4000);
+    ASSERT_EQ(P().PlaceTypeKernelScale[2], 4000);
+    ASSERT_EQ(P().PlaceTypeKernelScale[3], 4000);
+
+    ASSERT_EQ(P().PlaceTypeKernelShape[0], 3);
+    ASSERT_EQ(P().PlaceTypeKernelShape[1], 3);
+    ASSERT_EQ(P().PlaceTypeKernelShape[2], 3);
+    ASSERT_EQ(P().PlaceTypeKernelShape[3], 3);
+
+    ASSERT_EQ(P().PlaceTypeKernelType[0], 1);
+    ASSERT_EQ(P().PlaceTypeKernelType[1], 2);
+    ASSERT_EQ(P().PlaceTypeKernelType[2], 3);
+    ASSERT_EQ(P().PlaceTypeKernelType[3], 4);
+}
+TEST_F(Kernel, Defaulted) {
+    adUnit.kernelResolution.reset();
+    adUnit.kernelHigherResolutionFactor.reset();
+    adUnit.kernelShape.reset();
+    adUnit.kernelParam3.reset();
+    adUnit.kernelParam4.reset();
+    adUnit.kernelScaleParamForPlaces.reset();
+    adUnit.kernelShapeParamForPlaces.reset();
+    adUnit.kernelTypeForPlaces.reset();
+
+    adUnit.kernelScale = "3500";
+    adUnit.kernelType = "3";
+
+    SetupAndParseParams();
+
+    ASSERT_EQ(P().MoveKernelScale, 3500);
+
+    ASSERT_EQ(P().NKR, 4e6);
+    ASSERT_EQ(P().NK_HR, (4e6 / 1600));
+    ASSERT_EQ(P().MoveKernelShape, 1.0);
+    ASSERT_EQ(P().MoveKernelP3, 0);
+    ASSERT_EQ(P().MoveKernelP4, 0);
+
+    ASSERT_EQ(P().PlaceTypeKernelScale[0], 3500);
+    ASSERT_EQ(P().PlaceTypeKernelScale[1], 3500);
+    ASSERT_EQ(P().PlaceTypeKernelScale[2], 3500);
+    ASSERT_EQ(P().PlaceTypeKernelScale[3], 3500);
+
+    ASSERT_EQ(P().PlaceTypeKernelShape[0], 1.0);
+    ASSERT_EQ(P().PlaceTypeKernelShape[1], 1.0);
+    ASSERT_EQ(P().PlaceTypeKernelShape[2], 1.0);
+    ASSERT_EQ(P().PlaceTypeKernelShape[3], 1.0);
+
+    ASSERT_EQ(P().PlaceTypeKernelP3[0], 0);
+    ASSERT_EQ(P().PlaceTypeKernelP3[1], 0);
+    ASSERT_EQ(P().PlaceTypeKernelP3[2], 0);
+    ASSERT_EQ(P().PlaceTypeKernelP3[3], 0);
+
+    ASSERT_EQ(P().PlaceTypeKernelP4[0], 0);
+    ASSERT_EQ(P().PlaceTypeKernelP4[1], 0);
+    ASSERT_EQ(P().PlaceTypeKernelP4[2], 0);
+    ASSERT_EQ(P().PlaceTypeKernelP4[3], 0);
+
+    ASSERT_EQ(P().PlaceTypeKernelType[0], 3);
+    ASSERT_EQ(P().PlaceTypeKernelType[1], 3);
+    ASSERT_EQ(P().PlaceTypeKernelType[2], 3);
+    ASSERT_EQ(P().PlaceTypeKernelType[3], 3);
+}
+TEST_F(Kernel, MandatoryKernelType) {
+    adUnit.kernelType.reset();
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*`Kernel type");
+}
+TEST_F(Kernel, MandatoryKernelScale){
+    adUnit.kernelScale.reset();
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*`Kernel scale");
+}
+TEST_F(Kernel, MinKernelRes) {
+    adUnit.kernelResolution = "1999999";
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "[Kernel resolution] .* at least 2000000")
+}
+TEST_F(Kernel, KernalHigherFactorResMin) {
+    adUnit.kernelHigherResolutionFactor = "0";
+    adUnit.kernelResolution = "2000000";
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), R"REGEX(\[Kernel higher resolution factor\] needs to be in range)REGEX");
+}
+TEST_F(Kernel, KernalHigherFactorResMax) {
+    adUnit.kernelHigherResolutionFactor = "2000000";
+    adUnit.kernelResolution = "2000000";
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), R"REGEX(\[Kernel higher resolution factor\] needs to be in range)REGEX");
 }
 
 TEST_F(Output, Specified) {

--- a/src/tests/testParamParsing.cpp
+++ b/src/tests/testParamParsing.cpp
@@ -18,6 +18,7 @@ protected:
         args.preParamFile = "preParams.txt";
         args.adminFile = "admin.txt";
         args.r0 = "1.5";
+        args.maxThreads = "1";
     }
 
     void SetupAndParseParams() {
@@ -31,22 +32,159 @@ protected:
     }
 };
 
-class TimeStep: public ParamParsingTest{};
-
-TEST_F(TimeStep, ReadSteps) {
-    preParams.updateTimestep = "0.25";
-    SetupAndParseParams();
-    ASSERT_EQ(P().TimeStep, 0.25);
-}
-TEST_F(TimeStep, MandatoryUpdateTimestep) {
-    preParams.updateTimestep.reset();
-    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*Update timestep");
-}
-
 TEST_F(ParamParsingTest, DefaultValues) {
     SetupAndParseParams();
 }
 
+namespace {
+    class TimeStep: public ParamParsingTest{};
+    class Population: public ParamParsingTest {};
+    class Realisations: public ParamParsingTest {};
+    class SmallEpidemic: public ParamParsingTest {};
+    class Cells: public ParamParsingTest {};
+    class Households: public ParamParsingTest {};
+    class Output: public ParamParsingTest {};
+}
+
+TEST_F(Output, Specified) {
+    preParams.outputAge = "1";
+    preParams.outputSeverityAdminUnit = "1";
+    preParams.outputR0 = "1";
+    preParams.outputControls = "1";
+    preParams.outputCountry = "1";
+    preParams.outputAdUnitVar = "1";
+    preParams.outputHousehold = "1";
+    preParams.outputInfType = "1";
+    preParams.outputNonSeverity = "1";
+    preParams.outputNonSummaryResults = "1";
+    SetupAndParseParams();
+    ASSERT_EQ(P().OutputAge, 1);
+    ASSERT_EQ(P().OutputSeverityAdminUnit, 1);
+    ASSERT_EQ(P().OutputR0, 1);
+    ASSERT_EQ(P().OutputControls, 1);
+    ASSERT_EQ(P().OutputCountry, 1);
+    ASSERT_EQ(P().OutputAdUnitVar, 1);
+    ASSERT_EQ(P().OutputHousehold, 1);
+    ASSERT_EQ(P().OutputInfType, 1);
+    ASSERT_EQ(P().OutputNonSeverity, 1);
+    ASSERT_EQ(P().OutputNonSummaryResults, 1);
+}
+TEST_F(Output, Defaulted) {
+    preParams.outputAge.reset();
+    preParams.outputSeverityAdminUnit.reset();
+    preParams.outputR0.reset();
+    preParams.outputControls.reset();
+    preParams.outputCountry.reset();
+    preParams.outputAdUnitVar.reset();
+    preParams.outputHousehold.reset();
+    preParams.outputInfType.reset();
+    preParams.outputNonSeverity.reset();
+    preParams.outputNonSummaryResults.reset();
+    SetupAndParseParams();
+    ASSERT_EQ(P().OutputAge, 1);
+    ASSERT_EQ(P().OutputSeverityAdminUnit, 1);
+    ASSERT_EQ(P().OutputR0, 0);
+    ASSERT_EQ(P().OutputControls, 0);
+    ASSERT_EQ(P().OutputCountry, 0);
+    ASSERT_EQ(P().OutputAdUnitVar, 0);
+    ASSERT_EQ(P().OutputHousehold, 0);
+    ASSERT_EQ(P().OutputInfType, 0);
+    ASSERT_EQ(P().OutputNonSeverity, 0);
+    ASSERT_EQ(P().OutputNonSummaryResults, 0);
+}
+
+TEST_F(Households, Specified) {
+    adUnit.doHouseholds = "0";
+    SetupAndParseParams();
+    ASSERT_EQ(P().DoHouseholds, 0);
+}
+TEST_F(Households, Defaulted) {
+    adUnit.doHouseholds.reset();
+    SetupAndParseParams();
+    ASSERT_EQ(P().DoHouseholds, 1);
+}
+TEST_F(Cells, NumMicroCellsMandatory) {
+    preParams.numMicroCellsPerSpatialCell.reset();
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*`Number of micro-cells");
+}
+TEST_F(Cells, Specified) {
+    preParams.numMicroCellsPerSpatialCell = "9";
+    SetupAndParseParams();
+    ASSERT_EQ(P().NMCL, 9);
+}
+TEST_F(SmallEpidemic, Specified) {
+    preParams.maxNumForSmallOutbreak = "1000";
+    SetupAndParseParams();
+    ASSERT_EQ(P().SmallEpidemicCases, 1000);
+}
+TEST_F(SmallEpidemic, Defaulted) {
+    preParams.maxNumForSmallOutbreak.reset();
+    SetupAndParseParams();
+    ASSERT_EQ(P().SmallEpidemicCases, -1);
+}
+
+TEST_F(TimeStep, ReadSteps) {
+    preParams.updateTimestep = "0.25";
+    preParams.samplingTimestep = "1.5";
+    preParams.samplingTotalTime = "700";
+    SetupAndParseParams();
+    ASSERT_EQ(P().TimeStep, 0.25);
+    ASSERT_EQ(P().SampleStep, 1.5);
+    ASSERT_EQ(P().UpdatesPerSample, 6);
+    ASSERT_EQ(P().TimeStepsPerDay, 4);
+    ASSERT_EQ(P().SampleTime, 700);
+    ASSERT_EQ(P().NumSamples, 467 + 1);
+}
+TEST_F(TimeStep, SampleStepCanNotBeSmallerThanUpdateStep) {
+    preParams.updateTimestep = "0.25";
+    preParams.samplingTimestep = "0.125";
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Update step.*smaller.*sampling step");
+}
+TEST_F(TimeStep, MandatoryUpdateTimestep) {
+    preParams.updateTimestep.reset();
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*`Update timestep'");
+}
+TEST_F(TimeStep, MandatorySampleStep) {
+    preParams.samplingTimestep.reset();
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*`Sampling timestep'");
+}
+TEST_F(TimeStep, MandatorySamplingTime) {
+    preParams.samplingTotalTime.reset();
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*`Sampling time' ");
+}
+
+TEST_F(Realisations, Specified) {
+    preParams.numberOfRealisations = "2";
+    preParams.numberOfNonExtinctRealisations = "1";
+    preParams.onlyOutputNonExtinctRealisations = "1";
+    SetupAndParseParams();
+    EXPECT_EQ(P().NumRealisations, 2);
+    EXPECT_EQ(P().NumNonExtinctRealisations, 1);
+    EXPECT_EQ(P().OutputOnlyNonExtinct, 1);
+}
+TEST_F(Realisations, Mandatory) {
+    preParams.numberOfRealisations.reset();
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*`Number of realisations' ");
+}
+TEST_F(Realisations, DefaultValues) {
+    preParams.numberOfRealisations = "2";
+    preParams.numberOfNonExtinctRealisations.reset();
+    preParams.onlyOutputNonExtinctRealisations.reset();
+    SetupAndParseParams();
+    EXPECT_EQ(P().NumRealisations, 2);
+    EXPECT_EQ(P().NumNonExtinctRealisations, 2);
+    EXPECT_EQ(P().OutputOnlyNonExtinct, 0);
+}
+
+TEST_F(Population, Specified) {
+    adUnit.populationSize = "66000000";
+    SetupAndParseParams();
+    ASSERT_EQ(P().PopSize, 66000000);
+}
+TEST_F(Population, MandatoryParam) {
+    adUnit.populationSize.reset();
+    EXPECT_CRIT_ERROR(SetupAndParseParams(), "Unable to find .*`Population size' ");
+}
 
 
 


### PR DESCRIPTION
These changes add a googletest harness allowing us to unit test the behaviour of CovidSim.cpp. The initial focus is on building up command line and parameter tests - since once those can all be set programatically  from the test framework it will hopefully be simpler to create different starting scenarios to test the model functions themselves.

The intent is to allow updates from mrc-ide's branch to continue to be merged in, and so invasive changes to CovidSim.cpp have been kept to a bare minimum. A few changes were necessary however:
  - main() has been renamed _main in order to allow linking of CovidSim.cp into a test binary
  - The CommandLine parsing functionality in main() has been moved to its own function (but wherever possible no changes were made to the code itself)

The new .travis.yml kicks off the full set of unit tests as well as the UK regression. It should work out of the box by simply signing into traviscli with your github account and enabling this repo.